### PR TITLE
7902638: TestResult may count lines incorrectly

### DIFF
--- a/src/com/sun/javatest/TestResult.java
+++ b/src/com/sun/javatest/TestResult.java
@@ -2814,10 +2814,12 @@ public class TestResult {
             tsr.needsFinalNewline = false;
 
             // scan for newlines and characters requiring escapes
+            int lastCharPos = text.length() - 1;
             for (int i = 0; i < text.length(); i++) {
                 char c = text.charAt(i);
-                if (c < 32) {
-                    if (c == '\n') {
+                char nextChar = (i == lastCharPos) ? 0 : text.charAt(i + 1);
+                if (c < 32) {   // if it's "\r\n" sep we skip the \r and would count only the \n on the next step
+                    if ((c == '\n') || (c == '\r' && nextChar != '\n')) {
                         tsr.numLines++;
                     } else if (c != '\t' && c != '\r') {
                         tsr.numNonASCII++;
@@ -2837,7 +2839,7 @@ public class TestResult {
             // Note this must match the check when reading the text back in,
             // when we also check for just '\n' and not line.separator, because
             // line.separator now, and line.separator then, might be different.
-            if (!text.isEmpty() && !text.endsWith("\n")) {
+            if (!text.isEmpty() && !text.endsWith("\n") && !text.endsWith("\r") && !text.endsWith("\r\n")) {
                 tsr.needsFinalNewline = true;
                 tsr.numLines++;
             }

--- a/unit-tests/com/sun/javatest/TestResult_TextScanResult.java
+++ b/unit-tests/com/sun/javatest/TestResult_TextScanResult.java
@@ -69,7 +69,7 @@ public class TestResult_TextScanResult {
         assertEquals(1, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
-        assertTrue(scan.needsFinalNewline);
+        assertFalse(scan.needsFinalNewline);
     }
 
     @Test
@@ -89,7 +89,7 @@ public class TestResult_TextScanResult {
         assertEquals(1, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
-        assertTrue(scan.needsFinalNewline);
+        assertFalse(scan.needsFinalNewline);
     }
 
     @Test
@@ -103,13 +103,23 @@ public class TestResult_TextScanResult {
     }
 
     @Test
+    public void space_nr()  {
+        TestResult.TextScanResult scan = TestResult.TextScanResult.scan(" \n\r");
+        assertEquals(0, scan.numBackslashes);
+        assertEquals(2, scan.numLines);
+        assertEquals(0, scan.numNonASCII);
+        assertFalse(scan.needsEscape);
+        assertFalse(scan.needsFinalNewline);
+    }
+
+    @Test
     public void rr()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("\r\r");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(1, scan.numLines);
+        assertEquals(2, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
-        assertTrue(scan.needsFinalNewline);
+        assertFalse(scan.needsFinalNewline);
     }
 
     @Test
@@ -123,10 +133,43 @@ public class TestResult_TextScanResult {
     }
 
     @Test
+    public void nr()  {
+        TestResult.TextScanResult scan = TestResult.TextScanResult.scan("\n\r");
+        assertEquals(0, scan.numBackslashes);
+        assertEquals(2, scan.numLines);
+        assertEquals(0, scan.numNonASCII);
+        assertFalse(scan.needsEscape);
+        assertFalse(scan.needsFinalNewline);
+    }
+
+    @Test
     public void rnrn()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("\r\n\r\n");
         assertEquals(0, scan.numBackslashes);
         assertEquals(2, scan.numLines);
+        assertEquals(0, scan.numNonASCII);
+        assertFalse(scan.needsEscape);
+        assertFalse(scan.needsFinalNewline);
+    }
+
+    /**
+     * n, rn, r
+     */
+    @Test
+    public void nrnr()  {
+        TestResult.TextScanResult scan = TestResult.TextScanResult.scan("\n\r\n\r");
+        assertEquals(0, scan.numBackslashes);
+        assertEquals(3, scan.numLines);
+        assertEquals(0, scan.numNonASCII);
+        assertFalse(scan.needsEscape);
+        assertFalse(scan.needsFinalNewline);
+    }
+
+    @Test
+    public void nnnn()  {
+        TestResult.TextScanResult scan = TestResult.TextScanResult.scan("\n\n\n\n");
+        assertEquals(0, scan.numBackslashes);
+        assertEquals(4, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
         assertFalse(scan.needsFinalNewline);
@@ -196,7 +239,7 @@ public class TestResult_TextScanResult {
     public void twoLines_r()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\rsecond");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(1, scan.numLines);
+        assertEquals(2, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
         assertTrue(scan.needsFinalNewline);
@@ -223,23 +266,33 @@ public class TestResult_TextScanResult {
     }
 
     @Test
+    public void twoLines_n_endsWith_rn()  {
+        TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\nsecond\r\n");
+        assertEquals(0, scan.numBackslashes);
+        assertEquals(2, scan.numLines);
+        assertEquals(0, scan.numNonASCII);
+        assertFalse(scan.needsEscape);
+        assertFalse(scan.needsFinalNewline);
+    }
+
+    @Test
     public void twoLines_n_endsWith_r()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\nsecond\r");
         assertEquals(0, scan.numBackslashes);
         assertEquals(2, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
-        assertTrue(scan.needsFinalNewline);
+        assertFalse(scan.needsFinalNewline);
     }
 
     @Test
     public void twoLines_r_endsWith_r()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\rsecond\r");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(1, scan.numLines);
+        assertEquals(2, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
-        assertTrue(scan.needsFinalNewline);
+        assertFalse(scan.needsFinalNewline);
     }
 
     @Test
@@ -274,10 +327,20 @@ public class TestResult_TextScanResult {
     }
 
     @Test
+    public void threeLines_n_endsWith_n()  {
+        TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\nsecond\nthird\n");
+        assertEquals(0, scan.numBackslashes);
+        assertEquals(3, scan.numLines);
+        assertEquals(0, scan.numNonASCII);
+        assertFalse(scan.needsEscape);
+        assertFalse(scan.needsFinalNewline);
+    }
+
+    @Test
     public void threeLines_n_r()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\nsecond\rthird");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(2, scan.numLines);
+        assertEquals(3, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
         assertTrue(scan.needsFinalNewline);
@@ -287,7 +350,7 @@ public class TestResult_TextScanResult {
     public void threeLines_r_n()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\rsecond\nthird");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(2, scan.numLines);
+        assertEquals(3, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
         assertTrue(scan.needsFinalNewline);
@@ -297,17 +360,27 @@ public class TestResult_TextScanResult {
     public void threeLines_r_n_endsWith_r()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\rsecond\nthird\r");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(2, scan.numLines);
+        assertEquals(3, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
-        assertTrue(scan.needsFinalNewline);
+        assertFalse(scan.needsFinalNewline);
     }
 
     @Test
     public void threeLines_r_n_endsWith_n()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\rsecond\nthird\n");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(2, scan.numLines);
+        assertEquals(3, scan.numLines);
+        assertEquals(0, scan.numNonASCII);
+        assertFalse(scan.needsEscape);
+        assertFalse(scan.needsFinalNewline);
+    }
+
+    @Test
+    public void threeLines_n_n_endsWith_n()  {
+        TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\rsecond\nthird\n");
+        assertEquals(0, scan.numBackslashes);
+        assertEquals(3, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
         assertFalse(scan.needsFinalNewline);
@@ -317,7 +390,7 @@ public class TestResult_TextScanResult {
     public void threeLines_r_n_endsWith_rn()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\rsecond\nthird\r\n");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(2, scan.numLines);
+        assertEquals(3, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
         assertFalse(scan.needsFinalNewline);
@@ -327,7 +400,7 @@ public class TestResult_TextScanResult {
     public void threeLines_r_r()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\rsecond\rthird");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(1, scan.numLines);
+        assertEquals(3, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
         assertTrue(scan.needsFinalNewline);
@@ -357,7 +430,17 @@ public class TestResult_TextScanResult {
     public void threeLines_rn_r()  {
         TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\r\nsecond\rthird");
         assertEquals(0, scan.numBackslashes);
-        assertEquals(2, scan.numLines);
+        assertEquals(3, scan.numLines);
+        assertEquals(0, scan.numNonASCII);
+        assertFalse(scan.needsEscape);
+        assertTrue(scan.needsFinalNewline);
+    }
+
+    @Test
+    public void fourLines_nr_r()  {
+        TestResult.TextScanResult scan = TestResult.TextScanResult.scan("first\n\rsecond\rthird");
+        assertEquals(0, scan.numBackslashes);
+        assertEquals(4, scan.numLines);
         assertEquals(0, scan.numNonASCII);
         assertFalse(scan.needsEscape);
         assertTrue(scan.needsFinalNewline);


### PR DESCRIPTION
This is the fix for https://bugs.openjdk.java.net/browse/CODETOOLS-7902638
Changed behavior to handle not only "\n" as line ending but "\r" and "\r\n" as well.
Updated regression tests that were matching the current behavior and so started to fail.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902638](https://bugs.openjdk.java.net/browse/CODETOOLS-7902638): TestResult may count lines incorrectly


### Reviewers
 * Jonathan Gibbons ([jjg](@jonathan-gibbons) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jtharness pull/1/head:pull/1`
`$ git checkout pull/1`
