### PR TITLE
7902649: Allow a testsuite to define several TestFilters specific for this suite

### DIFF
--- a/src/com/sun/javatest/BasicParameters.java
+++ b/src/com/sun/javatest/BasicParameters.java
@@ -839,10 +839,7 @@ public abstract class BasicParameters
             v.add(statusFilter);
         }
 
-        TestFilter testSuiteFilter = getRelevantTestFilter();
-        if (testSuiteFilter != null) {
-            v.add(testSuiteFilter);
-        }
+        v.addAll(getAllRelevantFiltersInTheSuite());
 
         if (v.isEmpty()) {
             return null;

--- a/src/com/sun/javatest/InterviewParameters.java
+++ b/src/com/sun/javatest/InterviewParameters.java
@@ -1024,15 +1024,7 @@ public abstract class InterviewParameters
             v.add(statusFilter);
         }
 
-        TestFilter testSuiteFilter = null;
-        try {
-            testSuiteFilter = getRelevantTestFilter();
-        } catch (Exception e) {
-            testSuiteFilter = null;
-        }
-        if (testSuiteFilter != null) {
-            v.add(testSuiteFilter);
-        }
+        v.addAll(getAllRelevantFiltersInTheSuite());
 
         if (v.isEmpty()) {
             return null;

--- a/src/com/sun/javatest/Parameters.java
+++ b/src/com/sun/javatest/Parameters.java
@@ -27,6 +27,8 @@
 package com.sun.javatest;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -246,17 +248,38 @@ public interface Parameters {
     TestFilter getPriorStatusFilter();
 
     /**
-     * Get a test-suite specific filter which will filter tests according
-     * to test-suite-specific criteria, as perhaps determined by
+     * Get test-suite specific filters which will filter tests according
+     * to test-suite-specific criterias, as perhaps determined by
      * a configuration interview. For example, if the platform being tested
      * does not support some optional feature, the tests for that feature
      * could be automatically filtered out. If no such filter is required,
-     * null can be returned.
+     * empty collection can be returned.
      *
-     * @return a test-suite-specific filter, or null if no such filter is
+     * @return test-suite-specific filters, or empty collection if no such filter is
      * required.
      */
     TestFilter getRelevantTestFilter();
+
+    /**
+     * Get test-suite specific filters which will filter tests according
+     * to test-suite-specific criterias, as perhaps determined by
+     * a configuration interview. For example, if the platform being tested
+     * does not support some optional feature, the tests for that feature
+     * could be automatically filtered out. If no such filter is required,
+     * empty collection can be returned.
+     *
+     * @return test-suite-specific filters, or empty collection if no such filter is
+     * required.
+     */
+    default List<TestFilter> getAllRelevantFiltersInTheSuite() {
+        List<TestFilter> result = new ArrayList<>();
+        TestFilter relevantTestFilter = getRelevantTestFilter();
+        if (relevantTestFilter != null) {
+            result.add(relevantTestFilter);
+        }
+        result.addAll(getTestSuite().createTestFilters(getEnv()));
+        return result;
+    }
 
     /**
      * Get an array of the non-null filters returned from
@@ -268,7 +291,7 @@ public interface Parameters {
      * @see #getExcludeListFilter
      * @see #getKeywordsFilter
      * @see #getPriorStatusFilter
-     * @see #getRelevantTestFilter
+     * @see #getRelevantTestFilters
      */
     TestFilter[] getFilters();
 

--- a/src/com/sun/javatest/TestSuite.java
+++ b/src/com/sun/javatest/TestSuite.java
@@ -559,8 +559,8 @@ public class TestSuite {
      * required for this test suite.
      * @deprecated this method is deprecated, it is temporarily kept for easier migration
      * of client subclasses that provide their implementaitons of this method.
-     * To do the migration please override {@code createAdditionalTestFilters} to return a collection of filters (even having one element).
-     * Both this method and {@code createAdditionalTestFilters} are called by the framework and taken into account.
+     * To do the migration please override {@code createTestFilters} to return a collection of filters (even having one element).
+     * Both this method and {@code createTestFilters} are called by the framework and taken into account.
      */
     @java.lang.Deprecated
     public TestFilter createTestFilter(TestEnvironment filterEnv) {

--- a/src/com/sun/javatest/TestSuite.java
+++ b/src/com/sun/javatest/TestSuite.java
@@ -54,8 +54,11 @@ import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import java.util.logging.Handler;
@@ -554,9 +557,27 @@ public class TestSuite {
      * @param filterEnv Configuration data that may be used by the filter.
      * @return a test suite filter, or null if no test suite specific filter is
      * required for this test suite.
+     * @deprecated this method is deprecated, it is temporarily kept for easier migration
+     * of client subclasses that provide their implementaitons of this method.
+     * To do the migration please override {@code createAdditionalTestFilters} to return a collection of filters (even having one element).
+     * Both this method and {@code createAdditionalTestFilters} are called by the framework and taken into account.
      */
+    @java.lang.Deprecated
     public TestFilter createTestFilter(TestEnvironment filterEnv) {
         return null;
+    }
+
+    /**
+     * Create test suite specific filters to be used to filter the tests for a test run.
+     * The method should return empty collection if no test suite specific filtering is required.
+     * Default implementation of this method returns an empty collection.
+     * Both this method and {@code createTestFilter} are called by the framework and taken into account.
+     *
+     * @param filterEnv Configuration data that may be used by the filters.
+     * @return collection of test suite filters (if there are any)
+     */
+    public List<TestFilter> createTestFilters(TestEnvironment filterEnv) {
+        return Collections.emptyList();
     }
 
     /**

--- a/src/com/sun/javatest/exec/BasicSession.java
+++ b/src/com/sun/javatest/exec/BasicSession.java
@@ -38,6 +38,8 @@ import com.sun.javatest.util.I18NResourceBundle;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -224,15 +226,15 @@ public class BasicSession implements SessionExt {
         isSorted = true;
     }
 
-    public TestFilter getTestFilter(String name) {
+    public List<TestFilter> getTestFilter(String name) {
         if (config == null) {
             throw new IllegalStateException(i18n.getString("bc.configNotReady.err"));
         }
-        TestFilter tf;
+        List<TestFilter> filters;
         if (filterNames.contains(name)) {
-            tf = findFilter(name);
-            if (tf != null) {
-                return tf;
+            filters = findFilter(name);
+            if (!filters.isEmpty()) {
+                return filters;
             }
         }
         throw new IllegalArgumentException(i18n.getString("bc.unknownFilter.err", name));
@@ -244,17 +246,17 @@ public class BasicSession implements SessionExt {
      * @param name
      * @return found filter or null, if not found.
      */
-    protected TestFilter findFilter(String name) {
+    protected List<TestFilter> findFilter(String name) {
         if (EL_FILTER.equals(name)) {
-            return config.getExcludeListFilter();
+            return Arrays.asList(config.getExcludeListFilter());
         } else if (KWD_FILTER.equals(name)) {
-            return config.getKeywordsFilter();
+            return Arrays.asList(config.getKeywordsFilter());
         } else if (PRIOR_FILTER.equals(name)) {
-            return config.getPriorStatusFilter();
+            return Arrays.asList(config.getPriorStatusFilter());
         } else if (RELEVANT_FILTER.equals(name)) {
-            return config.getRelevantTestFilter();
+            return config.getAllRelevantFiltersInTheSuite();
         }
-        return null;
+        return Collections.emptyList();
     }
 
     public List<String> getTestFilterNames() {


### PR DESCRIPTION
Currently TestSuite class has a method to override that returns only one test filter:

TestFilter createTestFilter(TestEnvironment)

There are situations when test suite has several test filters that it is forced however to hide behind an umbrella filter. It is more natural and convenient to let test suite return a collection of atomized filters that would be iterated on the JTHarness side and listed in the test run stats separately and informatively.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902649](https://bugs.openjdk.java.net/browse/CODETOOLS-7902649): Allow testsuite to define several TestFilters specific for this suite


### Download
`$ git fetch https://git.openjdk.java.net/jtharness pull/2/head:pull/2`
`$ git checkout pull/2`
