### PR TITLE
7902702: Add basic unified console logging support

### DIFF
--- a/src/com/sun/javatest/util/Log.java
+++ b/src/com/sun/javatest/util/Log.java
@@ -1,0 +1,153 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+/**
+ * Provides simple console logging using java.util.logging API.
+ * Logging level is defined via "jtharness.logging.level" system property.
+ */
+public class Log {
+    public static final String JTHARNESS_LOGGING_LEVEL_SYS_PROP = "jtharness.logging.level";
+    private static Logger LOG;
+    private static Level CURRENT_LEVEL;
+    private static final String DATE_TIME_FORMAT = new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss ").format(new Date());
+
+    static {
+        resetLoggingSettings(Level.parse(System.getProperty(JTHARNESS_LOGGING_LEVEL_SYS_PROP, Level.INFO.getName())));
+    }
+
+    public static void resetLoggingSettings(Level newLevel) {
+        LOG = Logger.getLogger("jtharness");
+        CURRENT_LEVEL = newLevel;
+        ConsoleHandler handler = new ConsoleHandler();
+        handler.setFormatter(new SimpleFormatter() {
+            @Override
+            public synchronized String formatMessage(LogRecord lr) {
+                return createMessage(lr);
+            }
+
+            @Override
+            public synchronized String format(LogRecord lr) {
+                return createMessage(lr);
+            }
+
+            private String createMessage(LogRecord lr) {
+                return DATE_TIME_FORMAT + String.format("[%1$s] %2$s%n", lr.getLevel().getName(), lr.getMessage());
+            }
+        });
+        handler.setLevel(CURRENT_LEVEL);
+        // need not to have any extra console printing other that what our custom handler does
+        for (Handler defaultHandler : LOG.getHandlers()) {
+            LOG.removeHandler(defaultHandler);
+        }
+
+        LOG.setUseParentHandlers(false);
+        LOG.setLevel(CURRENT_LEVEL);
+        LOG.addHandler(handler);
+    }
+
+    public static void info(String message) {
+        // returning early to avoid unnecessary operations with stacktrace
+        if (!LOG.isLoggable(CURRENT_LEVEL)) {
+            return;
+        }
+        LOG.log(Level.INFO, callerPrefix() + message);
+    }
+
+    public static void finest(String message) {
+        // returning early to avoid unnecessary operations with stacktrace
+        if (!LOG.isLoggable(CURRENT_LEVEL)) {
+            return;
+        }
+        LOG.log(Level.FINEST, callerPrefix() + message);
+    }
+
+    public static void finer(String message) {
+        // returning early to avoid unnecessary operations with stacktrace
+        if (!LOG.isLoggable(CURRENT_LEVEL)) {
+            return;
+        }
+        LOG.log(Level.FINER, callerPrefix() + message);
+    }
+
+    public static void fine(String message) {
+        // returning early to avoid unnecessary operations with stacktrace
+        if (!LOG.isLoggable(CURRENT_LEVEL)) {
+            return;
+        }
+        LOG.log(Level.FINE, callerPrefix() + message);
+    }
+
+    public static void warning(String message) {
+        // returning early to avoid unnecessary operations with stacktrace
+        if (!LOG.isLoggable(CURRENT_LEVEL)) {
+            return;
+        }
+        LOG.log(Level.WARNING, callerPrefix() + message);
+    }
+
+    /**
+     * Corresponds to Level.SEVERE level
+     */
+    public static void error(String message) {
+        // returning early to avoid unnecessary operations with stacktrace
+        if (!LOG.isLoggable(CURRENT_LEVEL)) {
+            return;
+        }
+        LOG.log(Level.SEVERE, callerPrefix() + message);
+    }
+
+    /**
+     * Creates string prefix containing caller's class simple name and caller method names
+     */
+    private static String callerPrefix() {
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+        String result;
+        if (stackTrace.length >= 4) {
+            StackTraceElement stackTraceElement = stackTrace[3];
+            String callerClassName = stackTraceElement.getClassName();
+            String callingMethodName = stackTraceElement.getMethodName();
+            int lastDotIndex = callerClassName.lastIndexOf('.');
+            String simpleClassName = lastDotIndex < 0 ? callerClassName : callerClassName.substring(lastDotIndex + 1);
+            return "(" + simpleClassName + "." + callingMethodName + ") ";
+        } else {
+            result = "";
+        }
+        return result;
+    }
+
+}

--- a/unit-tests-support/com/sun/javatest/util/ConsoleLoggingTestBase.java
+++ b/unit-tests-support/com/sun/javatest/util/ConsoleLoggingTestBase.java
@@ -1,0 +1,77 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.util;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConsoleLoggingTestBase {
+
+    protected static final List<String> savedSystemErr = new ArrayList<>();
+
+    @BeforeClass
+    public static void init() {
+        System.setErr(new PrintStream(System.err) {
+            @Override
+            public void write(byte[] buf, int off, int len) {
+                super.write(buf, off, len);
+                String printed = new String(buf, off, len);
+                for (String s : printed.split("\n")) {
+                    savedSystemErr.add(s);
+                }
+            }
+        });
+
+    }
+
+    protected void checkSystemErrLineIs(int lineZeroBasedIndex, String expectedContent) {
+        Assert.assertEquals(expectedContent, savedSystemErr.get(lineZeroBasedIndex));
+    }
+
+    protected void checkSystemErrLineStartsWith(int lineZeroBasedIndex, String expectedPrefix) {
+        Assert.assertTrue(
+                "\"" + savedSystemErr.get(lineZeroBasedIndex) + "\" is expected to start with \"" + expectedPrefix + "\"",
+                savedSystemErr.get(lineZeroBasedIndex).startsWith(expectedPrefix));
+    }
+
+    protected void checkSystemErrLineContains(int lineZeroBasedIndex, String expectedInclusion) {
+        Assert.assertTrue(
+                "\"" + savedSystemErr.get(lineZeroBasedIndex) + "\" is expected to contain \"" + expectedInclusion + "\"",
+                savedSystemErr.get(lineZeroBasedIndex).contains(expectedInclusion));
+    }
+
+    protected void checkSystemErrLineEndsWith(int lineZeroBasedIndex, String expectedEnding) {
+        Assert.assertTrue(
+                "\"" + savedSystemErr.get(lineZeroBasedIndex) + "\" is expected to ends with \"" + expectedEnding + "\"",
+                savedSystemErr.get(lineZeroBasedIndex).endsWith(expectedEnding));
+    }
+}

--- a/unit-tests/com/sun/javatest/util/ConsoleLoggingTest.java
+++ b/unit-tests/com/sun/javatest/util/ConsoleLoggingTest.java
@@ -1,0 +1,258 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javatest.util;
+
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+public class ConsoleLoggingTest extends ConsoleLoggingTestBase {
+
+
+    @Test
+    public void levelALL() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.ALL);
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.info("info message 345");
+        Log.warning("warning message 345");
+        Log.error("error message 890");
+        Assert.assertEquals(6, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[FINE] (ConsoleLoggingTest.levelALL) fine message");
+        checkSystemErrLineEndsWith(1, "[FINER] (ConsoleLoggingTest.levelALL) finer message");
+        checkSystemErrLineEndsWith(2, "[FINEST] (ConsoleLoggingTest.levelALL) finest message");
+        checkSystemErrLineEndsWith(3, "[INFO] (ConsoleLoggingTest.levelALL) info message 345");
+        checkSystemErrLineEndsWith(4, "[WARNING] (ConsoleLoggingTest.levelALL) warning message 345");
+        checkSystemErrLineEndsWith(5, "[SEVERE] (ConsoleLoggingTest.levelALL) error message 890");
+    }
+
+    @Test
+    public void levelOFF() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.OFF);
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.info("info message 345");
+        Log.warning("warning message 345");
+        Log.warning("warning message 345697");
+        Log.error("error message 890");
+        Log.error("error message 893456");
+        Assert.assertTrue(savedSystemErr.isEmpty());
+    }
+
+    @Test
+    public void levelFINE() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.FINE);
+        Log.fine("fine message 23");
+        Log.finer("finer message 233");
+        Log.finest("finest message 662");
+        Log.info("info message 345");
+        Log.warning("warning message 345");
+        Log.error("error message 890");
+        Assert.assertEquals(4, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[FINE] (ConsoleLoggingTest.levelFINE) fine message 23");
+        checkSystemErrLineEndsWith(1, "[INFO] (ConsoleLoggingTest.levelFINE) info message 345");
+        checkSystemErrLineEndsWith(2, "[WARNING] (ConsoleLoggingTest.levelFINE) warning message 345");
+        checkSystemErrLineEndsWith(3, "[SEVERE] (ConsoleLoggingTest.levelFINE) error message 890");
+    }
+
+    @Test
+    public void levelFINER() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.FINER);
+        Log.fine("fine message 23");
+        Log.finer("finer message 233");
+        Log.finest("finest message 662");
+        Log.info("info message 345");
+        Log.warning("warning message 345");
+        Log.error("error message 890");
+        Assert.assertEquals(5, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[FINE] (ConsoleLoggingTest.levelFINER) fine message 23");
+        checkSystemErrLineEndsWith(1, "[FINER] (ConsoleLoggingTest.levelFINER) finer message 233");
+        checkSystemErrLineEndsWith(2, "[INFO] (ConsoleLoggingTest.levelFINER) info message 345");
+        checkSystemErrLineEndsWith(3, "[WARNING] (ConsoleLoggingTest.levelFINER) warning message 345");
+        checkSystemErrLineEndsWith(4, "[SEVERE] (ConsoleLoggingTest.levelFINER) error message 890");
+    }
+
+    @Test
+    public void levelFINEST() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.FINEST);
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.info("info message 345");
+        Log.warning("warning message 345");
+        Log.error("error message 890");
+        Assert.assertEquals(6, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[FINE] (ConsoleLoggingTest.levelFINEST) fine message");
+        checkSystemErrLineEndsWith(1, "[FINER] (ConsoleLoggingTest.levelFINEST) finer message");
+        checkSystemErrLineEndsWith(2, "[FINEST] (ConsoleLoggingTest.levelFINEST) finest message");
+        checkSystemErrLineEndsWith(3, "[INFO] (ConsoleLoggingTest.levelFINEST) info message 345");
+        checkSystemErrLineEndsWith(4, "[WARNING] (ConsoleLoggingTest.levelFINEST) warning message 345");
+        checkSystemErrLineEndsWith(5, "[SEVERE] (ConsoleLoggingTest.levelFINEST) error message 890");
+    }
+
+    @Test
+    public void levelINFO() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.INFO);
+        Log.info("info message 345");
+        Log.warning("warning message 345");
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.error("error message 890");
+        Assert.assertEquals(3, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[INFO] (ConsoleLoggingTest.levelINFO) info message 345");
+        checkSystemErrLineEndsWith(1, "[WARNING] (ConsoleLoggingTest.levelINFO) warning message 345");
+        checkSystemErrLineEndsWith(2, "[SEVERE] (ConsoleLoggingTest.levelINFO) error message 890");
+    }
+
+    @Test
+    public void levelWARNING() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.WARNING);
+        Log.info("info message 345");
+        Log.warning("warning message 3455");
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.finest("finest message 987");
+        Log.error("error message 8902");
+        Assert.assertEquals(2, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[WARNING] (ConsoleLoggingTest.levelWARNING) warning message 3455");
+        checkSystemErrLineEndsWith(1, "[SEVERE] (ConsoleLoggingTest.levelWARNING) error message 8902");
+    }
+
+
+    @Test
+    public void levelSEVERE() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.SEVERE);
+        Log.info("info message 345");
+        Log.warning("warning message 3455");
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.error("error message 356346");
+        Assert.assertEquals(1, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[SEVERE] (ConsoleLoggingTest.levelSEVERE) error message 356346");
+    }
+
+    @Test
+    public void levelSEVERE_2() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.SEVERE);
+        Log.info("info message 345");
+        Log.warning("warning message 3455");
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.error("error message 356346");
+        Log.error("error 2364 message 0398457");
+        Assert.assertEquals(2, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[SEVERE] (ConsoleLoggingTest.levelSEVERE_2) error message 356346");
+        checkSystemErrLineEndsWith(1, "[SEVERE] (ConsoleLoggingTest.levelSEVERE_2) error 2364 message 0398457");
+    }
+
+
+    @Test
+    public void levelInfo_threeFineMessages() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.INFO);
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Assert.assertTrue(savedSystemErr.isEmpty());
+    }
+
+    @Test
+    public void levelInfo_threeFineAndThreeWarnings() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.INFO);
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.warning("first warning!");
+        Log.warning("second warning!");
+        Log.warning("final warning!");
+        Assert.assertEquals(3, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[WARNING] (ConsoleLoggingTest.levelInfo_threeFineAndThreeWarnings) first warning!");
+        checkSystemErrLineEndsWith(1, "[WARNING] (ConsoleLoggingTest.levelInfo_threeFineAndThreeWarnings) second warning!");
+        checkSystemErrLineEndsWith(2, "[WARNING] (ConsoleLoggingTest.levelInfo_threeFineAndThreeWarnings) final warning!");
+    }
+
+    @Test
+    public void levelInfo_threeFineMessages_andAnError() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.INFO);
+        Log.fine("fine message");
+        Log.finer("finer message");
+        Log.finest("finest message");
+        Log.error("error message");
+        Assert.assertEquals(1, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[SEVERE] (ConsoleLoggingTest.levelInfo_threeFineMessages_andAnError) error message");
+    }
+
+    @Test
+    public void fineON() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.FINE);
+        Log.fine("fine message");
+        checkSystemErrLineEndsWith(0, "fine message");
+    }
+
+    @Test
+    public void info() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.INFO);
+        String message = "info message 1234";
+        Log.info(message);
+        checkSystemErrLineEndsWith(0, message);
+    }
+
+    @Test
+    public void error() {
+        savedSystemErr.clear();
+        Log.resetLoggingSettings(Level.INFO);
+        Log.error("error message 1234");
+        checkSystemErrLineContains(0, "(ConsoleLoggingTest.error) error message 1234");
+    }
+
+}
+

--- a/unit-tests/com/sun/javatest/util/ConsoleLoggingTestDefaultLevel.java
+++ b/unit-tests/com/sun/javatest/util/ConsoleLoggingTestDefaultLevel.java
@@ -1,0 +1,58 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javatest.util;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConsoleLoggingTestDefaultLevel extends ConsoleLoggingTestBase {
+
+    @Test
+    public void test() {
+        savedSystemErr.clear();
+        Log.info("info message 345-");
+        Log.warning("warning message 345-");
+        Log.fine("fine message-");
+        Log.finer("finer message-");
+        Log.finest("finest message-");
+        Log.error("error message 890-");
+        warningFromOtherMethod();
+        Assert.assertEquals(4, savedSystemErr.size());
+        checkSystemErrLineEndsWith(0, "[INFO] (ConsoleLoggingTestDefaultLevel.test) info message 345-");
+        checkSystemErrLineEndsWith(1, "[WARNING] (ConsoleLoggingTestDefaultLevel.test) warning message 345-");
+        checkSystemErrLineEndsWith(2, "[SEVERE] (ConsoleLoggingTestDefaultLevel.test) error message 890-");
+        checkSystemErrLineEndsWith(3,
+                "[WARNING] (ConsoleLoggingTestDefaultLevel.warningFromOtherMethod) warning message from other method");
+    }
+
+    private void warningFromOtherMethod() {
+        Log.warning("warning message from other method");
+    }
+
+}
+


### PR DESCRIPTION
7902702: Add basic unified console logging support

Adding centralized support for console logging using java.uti.logging API (since JT should be JavaSE 8 compatible)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902702](https://bugs.openjdk.java.net/browse/CODETOOLS-7902702): Add basic unified console logging support


### Download
`$ git fetch https://git.openjdk.java.net/jtharness pull/4/head:pull/4`
`$ git checkout pull/4`
