### PR TITLE
7902705: Make printed test filtering stats shorter

### DIFF
--- a/src/com/sun/javatest/batch/RunTestsCommand.java
+++ b/src/com/sun/javatest/batch/RunTestsCommand.java
@@ -199,7 +199,7 @@ class RunTestsCommand extends Command {
             TestFilter filter = entry.getKey();
             int number = entry.getValue().size();
             ctx.getLogWriter().println(number + " " + (number == 1 ? "test" : "tests") +
-                    " skipped by filter \"" + filter.getName() + "\", reason: " + filter.getReason());
+                    " skipped by filter \"" + filter.getName() + "\"");
         }
     }
 

--- a/unit-tests/com/sun/javatest/functional/CustomTestFilter.java
+++ b/unit-tests/com/sun/javatest/functional/CustomTestFilter.java
@@ -39,7 +39,7 @@ public class CustomTestFilter extends TestSuiteRunningTestBase {
         runJavaTest();
         checkSystemErrLineIs(6, "Test results: skipped: 3 ");
         checkSystemErrLineIs(7, "");
-        checkSystemErrLineIs(8, "3 tests skipped by filter \"My suite-specific test filter\", reason: Not going to allow any test to run");
+        checkSystemErrLineIs(8, "3 tests skipped by filter \"My suite-specific test filter\"");
         checkSystemErrLineStartsWith(9, "Report written to");
     }
 


### PR DESCRIPTION
7902705: Make printed test filtering stats shorter
Currently the filtering stats printed to console look like:

```
44 tests skipped by filter "Conditional selection", reason: Some "selectIf" conditions don't match environment "jck_runtime_macos"
3 tests skipped by filter "Excluded Tests", reason: Test appears on the exclude list.

```
However the reason of filtering could be rather long and more deserves to be present in the detailed HTML report; might better be skipped here.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902705](https://bugs.openjdk.java.net/browse/CODETOOLS-7902705): Make printed test filtering stats shorter


### Download
`$ git fetch https://git.openjdk.java.net/jtharness pull/5/head:pull/5`
`$ git checkout pull/5`
