### PR TITLE
7902788: RunTestsCommand should print Total/Setup/Cleanup times in a more human readable way

### DIFF
--- a/src/com/sun/javatest/batch/RunTestsCommand.java
+++ b/src/com/sun/javatest/batch/RunTestsCommand.java
@@ -166,7 +166,7 @@ class RunTestsCommand extends Command {
      * for example "2 days 1 minute 4 seconds".
      * This method doesn't generates weeks, months or years, only days
      * which is expected to be sufficient for printing total time taken by even a long test run.
-     * 
+     *
      * @param durationSeconds the seconds to convert to human-readable form
      * @return formatted representation, i.e. "1 hour 53 seconds"
      */

--- a/src/com/sun/javatest/batch/RunTestsCommand.java
+++ b/src/com/sun/javatest/batch/RunTestsCommand.java
@@ -43,11 +43,12 @@ import java.io.PrintWriter;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.TreeMap;
 
 class RunTestsCommand extends Command {
     private static final String DATE_OPTION = "date";
@@ -131,9 +132,9 @@ class RunTestsCommand extends Command {
                 long tt = h.getElapsedTime();
                 long setupT = h.getTotalSetupTime();
                 long cleanupT = h.getTotalCleanupTime();
-                ctx.printMessage(i18n, "runTests.totalTime", tt / 1000L);
-                ctx.printMessage(i18n, "runTests.setupTime", setupT / 1000L);
-                ctx.printMessage(i18n, "runTests.cleanupTime", cleanupT / 1000L);
+                ctx.printMessage(i18n, "runTests.totalTime", formattedDuration(tt / 1000L));
+                ctx.printMessage(i18n, "runTests.setupTime", formattedDuration(setupT / 1000L));
+                ctx.printMessage(i18n, "runTests.cleanupTime", formattedDuration(cleanupT / 1000L));
 
                 showResultStats(skipped, boStats);
             }
@@ -158,6 +159,42 @@ class RunTestsCommand extends Command {
         } catch (Harness.Fault e) {
             throw new Fault(i18n, "runTests.harnessError", e.getMessage());
         }
+    }
+
+    /**
+     * Converts the given duration in seconds to a more readable string representation:
+     * for example "2 days 1 minute 4 seconds".
+     * This method doesn't generates weeks, months or years, only days
+     * which is expected to be sufficient for printing total time taken by even a long test run.
+     * 
+     * @param durationSeconds the seconds to convert to human-readable form
+     * @return formatted representation, i.e. "1 hour 53 seconds"
+     */
+    public static String formattedDuration(long durationSeconds) {
+
+        if (durationSeconds < 1) {
+            return "0 seconds";
+        }
+        String result = "";
+        long remaining_seconds = durationSeconds;
+        // have to map duration to names to have durations sorted (TreeMap maintains order for keys)
+        TreeMap<Long, String> units = new TreeMap(Comparator.reverseOrder()) {{
+            put(1L, "second");
+            put(60L, "minute");
+            put(60L * 60L, "hour");
+            put(60L * 60L * 24L, "day");
+        }};
+        for (Map.Entry<Long, String> entry : units.entrySet()) {
+            long amount = remaining_seconds / entry.getKey();
+            if (amount > 0 ) {
+                remaining_seconds = remaining_seconds % entry.getKey();
+                result += " " + amount + " " + entry.getValue();
+                if (amount > 1) {
+                    result += "s";
+                }
+            }
+        }
+        return result.trim();
     }
 
     private void showResultStats(int skipped, int... stats) {

--- a/src/com/sun/javatest/batch/i18n.properties
+++ b/src/com/sun/javatest/batch/i18n.properties
@@ -53,17 +53,17 @@ observer.noClassName=No class name given
 observer.badArg=Bad option: {0}
 observer.badClassPath=Bad class path ({0}): {1}
 
-runTests.cleanupTime=Cleanup time = {0}s
+runTests.cleanupTime=Cleanup time: {0}
 runTests.error=Error: {0}
 runTests.harnessError=An error occurred while running the tests:\n{0}
 runTests.interrupted=The test run was interrupted.
 runTests.noTests=Test results: no tests selected
 runTests.resultsDone=Results written to {0}
-runTests.setupTime=Setup time = {0}s
+runTests.setupTime=Setup time: {0}
 runTests.tests=Test results: {0,choice,0#|0<passed: {0,number}}{1,choice,0#|1#; }{2,choice,0#|0<failed: {2,number}}{3,choice,0#|1#; }{4,choice,0#|0<error: {4,number}}{5,choice,0#|1#; }{6,choice,0#|0<not run: {6,number}}{7,choice,0#|1#; }{8,choice,0#|0<skipped: {8,number}} 
 runTests.testsInTheSuite=Tests found in the suite: {0,number}
 runTests.testsFailed=Error: Some tests did not pass
-runTests.totalTime=Total time = {0}s
+runTests.totalTime=Total time: {0}
 runTests.warnError=Warning: Test run completed, but problem(s) were detected in the test suite\nduring the run.
 
 

--- a/unit-tests/com/sun/javatest/batch/RunTestsCommand_formattedDuration.java
+++ b/unit-tests/com/sun/javatest/batch/RunTestsCommand_formattedDuration.java
@@ -1,0 +1,187 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javatest.batch;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import java.util.List;
+
+/**
+ * Checking function that produces strings with human readable duration, i.e. "2 hours 31 minutes 1 second"
+ */
+public class RunTestsCommand_formattedDuration {
+
+    public static class Clazz {
+        public void method() { }
+    }
+    
+    @Test
+    public void zero() {
+        Assert.assertEquals("0 seconds", RunTestsCommand.formattedDuration(0));
+        Assert.assertEquals("0 seconds", RunTestsCommand.formattedDuration(-1));
+        Assert.assertEquals("0 seconds", RunTestsCommand.formattedDuration(-400));
+        Assert.assertEquals("0 seconds", RunTestsCommand.formattedDuration(Integer.MIN_VALUE));
+        Assert.assertEquals("0 seconds", RunTestsCommand.formattedDuration(Long.MIN_VALUE));
+    }
+
+    @Test
+    public void maxValues() {
+        Assert.assertEquals("24855 days 3 hours 14 minutes 7 seconds",
+                RunTestsCommand.formattedDuration(Integer.MAX_VALUE));
+        Assert.assertEquals(
+                24855 * 60 * 60 * 24 + 60 * 60 * 3 + 60 * 14 + 7,
+                Integer.MAX_VALUE
+        );
+
+        Assert.assertEquals("106751991167300 days 15 hours 30 minutes 7 seconds",
+                RunTestsCommand.formattedDuration(Long.MAX_VALUE));
+        Assert.assertEquals(
+                106751991167300L * 60L * 60L * 24L + 60L * 60L * 15L + 60L * 30L + 7L,
+                Long.MAX_VALUE
+        );
+    }
+
+    @Test
+    public void seconds() {
+        Assert.assertEquals("1 second", RunTestsCommand.formattedDuration(1));
+        Assert.assertEquals("2 seconds", RunTestsCommand.formattedDuration(2));
+        Assert.assertEquals("3 seconds", RunTestsCommand.formattedDuration(3));
+        Assert.assertEquals("30 seconds", RunTestsCommand.formattedDuration(30));
+        Assert.assertEquals("40 seconds", RunTestsCommand.formattedDuration(40));
+        Assert.assertEquals("59 seconds", RunTestsCommand.formattedDuration(59));
+    }
+
+    @Test
+    public void minutes() {
+        Assert.assertEquals("1 minute", RunTestsCommand.formattedDuration(60));
+        Assert.assertEquals("2 minutes", RunTestsCommand.formattedDuration(120));
+        Assert.assertEquals("3 minutes", RunTestsCommand.formattedDuration(180));
+        Assert.assertEquals("10 minutes", RunTestsCommand.formattedDuration(600));
+        Assert.assertEquals("59 minutes", RunTestsCommand.formattedDuration(60 * 59));
+        Assert.assertEquals("11 minutes", RunTestsCommand.formattedDuration(660));
+    }
+
+    @Test
+    public void hours() {
+        Assert.assertEquals("1 hour", RunTestsCommand.formattedDuration(60 * 60));
+        Assert.assertEquals("7 hours", RunTestsCommand.formattedDuration(60 * 60 * 7));
+        Assert.assertEquals("23 hours", RunTestsCommand.formattedDuration(60 * 60 * 23));
+    }
+
+    @Test
+    public void days() {
+        Assert.assertEquals("1 day", RunTestsCommand.formattedDuration(60 * 60 * 24));
+        Assert.assertEquals("2 days", RunTestsCommand.formattedDuration(60 * 60 * 48));
+        Assert.assertEquals("7 days", RunTestsCommand.formattedDuration(60 * 60 * 24 * 7));
+        Assert.assertEquals("100 days", RunTestsCommand.formattedDuration(60 * 60 * 24 * 100));
+    }
+
+    @Test
+    public void days_hours() {
+        Assert.assertEquals("1 day 1 hour", RunTestsCommand.formattedDuration(60 * 60 * 25));
+        Assert.assertEquals("2 days 3 hours", RunTestsCommand.formattedDuration(60 * 60 * 51));
+        Assert.assertEquals("2 days 23 hours", RunTestsCommand.formattedDuration(60 * 60 * 71));
+    }
+
+    @Test
+    public void days_hours_minutes() {
+        Assert.assertEquals("1 day 1 hour 1 minute", RunTestsCommand.formattedDuration(60 * 60 * 25 + 60));
+        Assert.assertEquals("1 day 5 hours 3 minutes", RunTestsCommand.formattedDuration(60 * 60 * 29 + 180));
+    }
+
+    @Test
+    public void days_seconds() {
+        Assert.assertEquals("1 day 59 seconds", RunTestsCommand.formattedDuration(60 * 60 * 24 + 59));
+        Assert.assertEquals("1 day 1 second", RunTestsCommand.formattedDuration(60 * 60 * 24 + 1));
+        Assert.assertEquals("1 day 2 seconds", RunTestsCommand.formattedDuration(60 * 60 * 24 + 2));
+        Assert.assertEquals("3 days 1 second", RunTestsCommand.formattedDuration(60 * 60 * 72 + 1));
+    }
+
+    @Test
+    public void days_minutes() {
+        Assert.assertEquals("1 day 2 minutes", RunTestsCommand.formattedDuration(60 * 60 * 24 + 120));
+        Assert.assertEquals("1 day 10 minutes", RunTestsCommand.formattedDuration(60 * 60 * 24 + 600));
+    }
+
+    @Test
+    public void days_hours_minutes_seconds() {
+        Assert.assertEquals("1 day 1 hour 1 minute 4 seconds", RunTestsCommand.formattedDuration(60 * 60 * 25 + 64));
+        Assert.assertEquals("1 day 1 hour 2 minutes 7 seconds", RunTestsCommand.formattedDuration(60 * 60 * 25 + 127));
+        Assert.assertEquals("2 days 1 hour 2 minutes 7 seconds", RunTestsCommand.formattedDuration(60 * 60 * 49 + 127));
+    }
+
+    @Test
+    public void days_minutes_seconds() {
+        Assert.assertEquals("1 day 8 minutes 15 seconds", RunTestsCommand.formattedDuration(60 * 60 * 24 + 60*8 + 15));
+        Assert.assertEquals("2 days 1 minute 4 seconds", RunTestsCommand.formattedDuration(60 * 60 * 48 + 64));
+    }
+
+    @Test
+    public void days_hours_seconds() {
+        Assert.assertEquals("1 day 1 hour 4 seconds", RunTestsCommand.formattedDuration(60 * 60 * 25 + 4));
+        Assert.assertEquals("1 day 23 hours 59 seconds", RunTestsCommand.formattedDuration(60 * 60 * 47 + 59));
+    }
+
+    @Test
+    public void minutes_seconds() {
+        Assert.assertEquals("1 minute 1 second", RunTestsCommand.formattedDuration(61));
+        Assert.assertEquals("1 minute 59 seconds", RunTestsCommand.formattedDuration(119));
+        Assert.assertEquals("2 minutes 1 second", RunTestsCommand.formattedDuration(121));
+        Assert.assertEquals("2 minutes 3 seconds", RunTestsCommand.formattedDuration(123));
+        Assert.assertEquals("2 minutes 6 seconds", RunTestsCommand.formattedDuration(126));
+        Assert.assertEquals("3 minutes 11 seconds", RunTestsCommand.formattedDuration(191));
+        Assert.assertEquals("10 minutes 1 second", RunTestsCommand.formattedDuration(601));
+        Assert.assertEquals("10 minutes 5 seconds", RunTestsCommand.formattedDuration(605));
+        Assert.assertEquals("10 minutes 59 seconds", RunTestsCommand.formattedDuration(659));
+    }
+
+    @Test
+    public void hours_minutes() {
+        Assert.assertEquals("1 hour 40 minutes", RunTestsCommand.formattedDuration(6000));
+        Assert.assertEquals("1 hour 41 minutes", RunTestsCommand.formattedDuration(6060));
+        Assert.assertEquals("1 hour 59 minutes", RunTestsCommand.formattedDuration(60 * 60 + 60 * 59));
+    }
+
+    @Test
+    public void hours_seconds() {
+        Assert.assertEquals("19 hours 15 seconds", RunTestsCommand.formattedDuration(60 * 60 * 19 + 15));
+    }
+
+    @Test
+    public void hours_minutes_seconds() {
+        Assert.assertEquals("1 hour 41 minutes 7 seconds", RunTestsCommand.formattedDuration(6067));
+        Assert.assertEquals("5 hours 45 minutes 45 seconds", RunTestsCommand.formattedDuration(45 + 60*45 + 60*60*5));
+    }
+
+
+}

--- a/unit-tests/com/sun/javatest/batch/RunTestsCommand_formattedDuration.java
+++ b/unit-tests/com/sun/javatest/batch/RunTestsCommand_formattedDuration.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,6 @@ import java.util.List;
  */
 public class RunTestsCommand_formattedDuration {
 
-    public static class Clazz {
-        public void method() { }
-    }
-    
     @Test
     public void zero() {
         Assert.assertEquals("0 seconds", RunTestsCommand.formattedDuration(0));


### PR DESCRIPTION
Curently RunTestsCommand class prints the total exec time upon run completion the following way, always giving only the number of seconds:

```
Total time = 0s
Total time = 323s
Total time = 2,949s
```
This is to improve total time logging, shaping it in a more human-readable way, for example

`Total time: 5 minutes 32 seconds `

Same formatting looks reasonable to apply to setup and cleanup time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902788](https://bugs.openjdk.java.net/browse/CODETOOLS-7902788): RunTestsCommand should print Total/Setup/Cleanup times in a more human readable way


### Download
`$ git fetch https://git.openjdk.java.net/jtharness pull/7/head:pull/7`
`$ git checkout pull/7`
