### PR TITLE
7902794: Provide a `release` file for JT Harness builds

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -23,7 +23,7 @@
   or visit www.oracle.com if you need additional information or have any
   questions.
 -->
-<project name="jtharness" default="build" basedir="..">
+<project name="jtharness" default="build" basedir=".." xmlns:if="ant:if" xmlns:unless="ant:unless">
 
     <import file="build-i18ncheck.xml"/>
     <import file="check-dependencies.xml"/>
@@ -241,7 +241,7 @@
 
     <!-- JAR Section -->
 
-    <target name="jar" depends="jar.check,stamp" unless="javatest.jar.ok" description="Build JAR.">
+    <target name="jar" depends="jar.check,stamp, generate.release.file" unless="javatest.jar.ok" description="Build JAR.">
         <mkdir dir="${BUILD_DIR}/binaries/lib"/>
         <jar destfile="${BUILD_DIR}/binaries/lib/javatest.jar" basedir="${build.classes}" index="false">
             <manifest>
@@ -254,6 +254,23 @@
             <include name="META-INF/services/com.sun.javatest.report.ReportFormat"/>
             <patternset refid="javatest.packages.jar"/>
         </jar>
+    </target>
+
+    <target name="generate.release.file">
+        <tstamp>
+            <format property="BUILD_DATE" pattern="MMM dd, YYYY" locale="en,GB"/>
+        </tstamp>
+        <available file="git" type="file" filepath="${env.PATH}" property="GIT_FOUND"/>
+        <exec if:set="GIT_FOUND" executable="git"
+              failonerror="false"
+              failifexecutionfails="false"
+              outputproperty="BUILT_FROM_COMMIT">
+            <arg line="log -1 --format=%H"/>
+        </exec>
+        <echo unless:set="GIT_FOUND">'git' command not found on the system path, unable to identify latest commit ID</echo>
+        <echo file="${BUILD_DIR}/binaries/release">JTHARNESS_VERSION=${build.version} ${build.number}${line.separator}</echo>
+        <echo append="true" file="${BUILD_DIR}/binaries/release">BUILD_DATE=${BUILD_DATE}${line.separator}</echo>
+        <echo if:set="BUILT_FROM_COMMIT" append="true" file="${BUILD_DIR}/binaries/release">SOURCE=jtharness:${BUILT_FROM_COMMIT}${line.separator}</echo>
     </target>
 
     <target name="jar.check" depends="compile">


### PR DESCRIPTION
generating 'release' file for any call of 'jar' target (or any target depending on 'jar') with approximately the following content:

```
JTHARNESS_VERSION=6.0 b15
BUILD_DATE=Nov 11, 2020
SOURCE=jtharness:04050d3f6754491a67c71a7a98a34a7a00d4eb62
```

The last line won't be included if 'git' is not found on the system path.
Still assuming that jtharness repository is under Git VCS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902794](https://bugs.openjdk.java.net/browse/CODETOOLS-7902794): Provide a `release` file for JT Harness builds


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jtharness pull/8/head:pull/8`
`$ git checkout pull/8`
