### PR TITLE
7903017: RunTestsHandler passes arguments to lastIndexOf in the wrong order

### DIFF
--- a/src/com/sun/javatest/exec/RunTestsHandler.java
+++ b/src/com/sun/javatest/exec/RunTestsHandler.java
@@ -125,7 +125,7 @@ class RunTestsHandler implements ET_RunTestControl, Session.Observer {
         for (String curr : requested) {
             for (String iTest : iTests) {
                 int slash = curr.lastIndexOf('/');
-                int pound = slash == -1 ? curr.lastIndexOf('#') : curr.lastIndexOf(slash, '#');
+                int pound = slash == -1 ? curr.lastIndexOf('#') : curr.lastIndexOf('#', slash);
 
                 if (curr.startsWith(iTest) &&
                         (curr.length() == iTest.length() || curr.charAt(iTest.length()) == '#' ||
@@ -140,7 +140,7 @@ class RunTestsHandler implements ET_RunTestControl, Session.Observer {
         for (String curr : iTests) {
             for (String aRequested : requested) {
                 int slash = curr.lastIndexOf('/');
-                int pound = slash == -1 ? curr.lastIndexOf('#') : curr.lastIndexOf(slash, '#');
+                int pound = slash == -1 ? curr.lastIndexOf('#') : curr.lastIndexOf('#', slash);
 
                 if (curr.startsWith(aRequested) &&
                         (curr.length() == aRequested.length() || curr.charAt(aRequested.length()) == '#' ||


### PR DESCRIPTION
This fixes a bug where the arguments to to `lastIndexOf` were swapped.

The first argument to `String#lastIndexOf(int, int)` is a character to search for, the second argument is a start index.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903017](https://bugs.openjdk.java.net/browse/CODETOOLS-7903017): RunTestsHandler passes arguments to lastIndexOf in the wrong order


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.java.net/jtharness pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/12.diff">https://git.openjdk.java.net/jtharness/pull/12.diff</a>

</details>
