### PR TITLE
7903036: Sanity Tests - Adding three JavaTest GUI automated sanity test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSW1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSW1.java
@@ -1,0 +1,104 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextAreaOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+
+public class Test_QSW1 extends Config_New {
+    // This test case checks if Quick Start wizard Shows correct display text and
+    // next and back button works.
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_QSW1");
+    }
+
+    @Test
+    public void test() {
+        // Selecting the quick start dialog box and checking the header.
+        JDialogOperator quickstart = new JDialogOperator(getExecResource("qsw.title"));
+        JTextFieldOperator qsw_header = new JTextFieldOperator(quickstart, 0);
+
+        // Checking header text
+        assertEquals("Failed because of Incorrect header text - ", "Welcome to the JT Harness!", qsw_header.getText());
+
+        // Checking Text inside the body.
+        JTextAreaOperator qsw_text = new JTextAreaOperator(quickstart, 0);
+        assertEquals("Failed because of Incorrect text in text body - ",
+                "This Quick Start Guide will lead you through the process of setting up the JT Harness to perform common tasks.\n"
+                        + "\n" + "Which of the following tasks do you want to do?",
+                qsw_text.getText());
+
+        // Selecting the next and back buttons.
+        JButtonOperator next = new JButtonOperator(quickstart, 1);
+        JButtonOperator back = new JButtonOperator(quickstart, 0);
+
+        // Selecting the checkbox named 'start a new run'.
+        JTextFieldOperator qsw_temp;
+        JRadioButtonOperator qsw_check = new JRadioButtonOperator(quickstart, 0);
+        qsw_check.push();
+        next.push();
+
+        // Checking text header that appears after next button is press.
+        qsw_temp = new JTextFieldOperator(quickstart, 0);
+        assertEquals("Failed because of Incorrect header text - ", "Test Suite", qsw_temp.getText());
+        back.push();
+
+        // Repeating the above process for 2 more times for the remaining 2 radio
+        // buttons on the main QS wizard dialog.
+        qsw_temp = new JTextFieldOperator(quickstart, 0);
+        assertEquals("Failed because of Incorrect header text - ", "Welcome to the JT Harness!", qsw_temp.getText());
+
+        qsw_check = new JRadioButtonOperator(quickstart, 1);
+        qsw_check.push();
+
+        next.push();
+        qsw_temp = new JTextFieldOperator(quickstart, 0);
+        assertEquals("Failed because of Incorrect header text - ", "Work Directory", qsw_temp.getText());
+
+        back.push();
+        qsw_temp = new JTextFieldOperator(quickstart, 0);
+        assertEquals("Failed because of Incorrect header text - ", "Welcome to the JT Harness!", qsw_temp.getText());
+
+        qsw_check = new JRadioButtonOperator(quickstart, 2);
+        qsw_check.push();
+        next.push();
+        qsw_temp = new JTextFieldOperator(quickstart, 0);
+        assertEquals("Failed because of Incorrect header text - ", "Test Suite", qsw_temp.getText());
+
+        back.push();
+        qsw_temp = new JTextFieldOperator(quickstart, 0);
+        assertEquals("Failed because of Incorrect header text - ", "Welcome to the JT Harness!", qsw_temp.getText());
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSW2.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSW2.java
@@ -1,0 +1,110 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JCheckBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+
+public class Test_QSW2 extends Config_New {
+    // This test case checks if Quick Start wizard Opens up configuration editor.
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_QSW2");
+    }
+
+    @Test
+    public void test() {
+        // Selecting the quick start dialog box and checking the header.
+        JDialogOperator quickstart = new JDialogOperator(getExecResource("qsw.title"));
+
+        // Selecting the next and back buttons.
+        JButtonOperator next = new JButtonOperator(quickstart, 1);
+
+        // Selecting the checkbox named 'start a new run'.
+        JRadioButtonOperator qsw_check = new JRadioButtonOperator(quickstart, 0);
+        qsw_check.push();
+        next.push();
+
+        // pressing browse button.
+        JButtonOperator browse = new JButtonOperator(quickstart, 0);
+        browse.push();
+
+        // Selecting Test suite to open.
+        JDialogOperator opentestdialog = new JDialogOperator(getToolResource("tsc.title"));
+        new JTextFieldOperator(opentestdialog, "").enterText("demots");
+        next.push();
+
+        // Selecting the configuration template radio button and then selecting the
+        // configuration file.
+        JRadioButtonOperator test = new JRadioButtonOperator(quickstart, 0);
+        test.push();
+        next.push();
+        browse = new JButtonOperator(quickstart, 0);
+        browse.push();
+        JDialogOperator createworkdialog = new JDialogOperator(getToolResource("wdc.new.title"));
+        new JTextFieldOperator(createworkdialog, "").enterText("temp_qsw_dir1");
+        next.push();
+
+        // Selecting and testing check box function.
+        JCheckBoxOperator start_ce = new JCheckBoxOperator(quickstart, 0);
+        JCheckBoxOperator start_test = new JCheckBoxOperator(quickstart, 1);
+
+        if (!start_ce.isSelected()) {
+            fail("Expected: Start configuration Editor check box should be selected by default. \nActual: Start configuration Editor check box not selected by default.");
+        }
+
+        start_ce.push();
+        start_test.push();
+
+        if (start_test.isSelected() && !start_ce.isSelected()) {
+            fail("Expected: Start test run checkbox should not select without Start configuration Editor check box being set. \nActual: Start test run checkbox is selected without start config editor check box being set.");
+        }
+
+        // Pressing finish button.
+        start_test.push();
+        JButtonOperator finish = new JButtonOperator(quickstart, 2);
+        finish.push();
+
+        if (quickstart.isVisible()) {
+            fail("Expected: Quick Start Wizard should not visible after clicking on finish button. \nActual: Quick Start Wizard is still visible even after clicking on finish.");
+        }
+
+        // Waiting for the configuration editor to open up.
+        JDialogOperator config_editor = new JDialogOperator(getExecResource("ce.name"));
+
+        if (!config_editor.isVisible()) {
+            fail("Expected: Configuration Editor should visible after closing Quick Start Wizard. \nActual: Configuration Editor is not visible after closing Quick Start Wizard.");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSW3.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSW3.java
@@ -1,0 +1,139 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JCheckBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class Test_QSW3 extends Config_New {
+    // This test case checks if Quick Start wizard starts running test when start
+    // test check box is clicked and a valid configuration file is loaded.
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_QSW3");
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        // Selecting the quick start dialog box and checking the header.
+        JDialogOperator quickstart = new JDialogOperator(getExecResource("qsw.title"));
+
+        // Selecting the next and back buttons.
+        JButtonOperator next = new JButtonOperator(quickstart, 1);
+
+        // Selecting the checkbox named 'start a new run'.
+        JRadioButtonOperator qsw_check = new JRadioButtonOperator(quickstart, 0);
+        qsw_check.push();
+        next.push();
+
+        // pressing browse button.
+        JButtonOperator browse = new JButtonOperator(quickstart, 0);
+        browse.push();
+
+        // Selecting Test suite to open.
+        JDialogOperator opentestdialog = new JDialogOperator(getToolResource("tsc.title"));
+        new JTextFieldOperator(opentestdialog, "").enterText("demots");
+        next.push();
+
+        // Selecting the configuration template radio button and then selecting the
+        // configuration file.
+        JRadioButtonOperator test = new JRadioButtonOperator(quickstart, 1);
+        test.push();
+
+        Path p = Paths.get("democonfig.jti");
+        String configfile = p.toAbsolutePath().toString();
+        System.out.println(configfile);
+
+        browse = new JButtonOperator(quickstart, 0);
+        browse.push();
+        JDialogOperator loadconfig = new JDialogOperator(getExecResource("ce.load.title"));
+        new JTextFieldOperator(loadconfig, "").enterText(configfile);
+        next.push();
+
+        // Creating directory.
+        browse = new JButtonOperator(quickstart, 0);
+        browse.push();
+        JDialogOperator createworkdialog = new JDialogOperator(getToolResource("wdc.new.title"));
+        new JTextFieldOperator(createworkdialog, "").enterText("temp_qsw_dir7");
+        next.push();
+
+        // Selecting and testing check box function.
+        JCheckBoxOperator start_ce = new JCheckBoxOperator(quickstart, 0);
+        JCheckBoxOperator start_test = new JCheckBoxOperator(quickstart, 1);
+
+        if (!start_ce.isSelected()) {
+            fail("Expected: Start configuration Editor check box should be selected by default. \nActual: Start configuration Editor check box is not selected by default.");
+        }
+
+        start_ce.push();
+        start_test.push();
+
+        if (start_test.isSelected() && start_ce.isSelected()) {
+            fail("Expected: Selecting Start test run checkbox should not select Start configuration Editor checkbox. \nActual: Selecting Start test run checkbox has selected Start configuration Editor checkbox.");
+        }
+
+        JButtonOperator finish = new JButtonOperator(quickstart, 2);
+        finish.push();
+
+        if (quickstart.isVisible()) {
+            fail("Expected: Quick Start Wizard should not visible after clicking on finish button. \nActual: Quick Start Wizard is still visible even after clicking on finish button.");
+        }
+
+        // Check that tests started performing.
+        JTextFieldOperator strip = new JTextFieldOperator(mainFrame, new NameComponentChooser("strip.msg"));
+        int time = 0;
+
+        // Waiting for Execution of tests to finish.
+        while (time < 60) {
+            if (strip.getText().startsWith("Finished")) {
+                break;
+            } else if (!strip.getText().startsWith("Running")) {
+                fail("Expected: message starting with 'Running' has to be displayed in the strip message field. \nActual: wrong message "
+                        + strip.getText() + "is displayed in the strip message field.");
+            } else {
+                // Sleeping for one second if message in strip starts with 'Running'.
+                Thread.sleep(1000);
+            }
+        }
+
+        assertTrue("Expected: tests should run successfully. \nActual: Error while tests are running.",
+                strip.getText().startsWith("Finished"));
+
+    }
+}


### PR DESCRIPTION
Adding below automated JavaTest GUI Sanity Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.Test_QSW1.java
2.Test_QSW2.java
3.Test_QSW3.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903036](https://bugs.openjdk.java.net/browse/CODETOOLS-7903036): Sanity Tests - Adding three JavaTest GUI automated sanity test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/jtharness pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/15.diff">https://git.openjdk.java.net/jtharness/pull/15.diff</a>

</details>
