### PR TITLE
7903074: Feature Tests - Adding three JavaTest GUI legacy automated feature test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Browse/Browse3.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse3.java
@@ -1,0 +1,47 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Browse;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+public class Browse3 extends Browse {
+
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.Browse.Browse3");
+	}
+
+	@Test
+	public void testBrowse3() {
+
+		browseTestsuite(quickStartDialog);
+
+		next(quickStartDialog);
+
+		getTextField(quickStartDialog, "Test Suite");
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse3.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse3.java
@@ -31,17 +31,17 @@ import org.junit.runner.JUnitCore;
 
 public class Browse3 extends Browse {
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.Browse.Browse3");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Browse.Browse3");
+    }
 
-	@Test
-	public void testBrowse3() {
+    @Test
+    public void testBrowse3() {
 
-		browseTestsuite(quickStartDialog);
+        browseTestsuite(quickStartDialog);
 
-		next(quickStartDialog);
+        next(quickStartDialog);
 
-		getTextField(quickStartDialog, "Test Suite");
-	}
+        getTextField(quickStartDialog, "Test Suite");
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse4.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse4.java
@@ -1,0 +1,52 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Browse;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+public class Browse4 extends Browse {
+
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.Browse.Browse4");
+	}
+
+	@Test
+	public void testBrowse4() {
+		browseTestsuite(quickStartDialog);
+
+		next(quickStartDialog);
+
+		pickDefaultTestsuite(quickStartDialog);
+
+		next(quickStartDialog);
+
+		useConfigTemplate(quickStartDialog);
+
+		next(quickStartDialog);
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse4.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse4.java
@@ -31,22 +31,22 @@ import org.junit.runner.JUnitCore;
 
 public class Browse4 extends Browse {
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.Browse.Browse4");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Browse.Browse4");
+    }
 
-	@Test
-	public void testBrowse4() {
-		browseTestsuite(quickStartDialog);
+    @Test
+    public void testBrowse4() {
+        browseTestsuite(quickStartDialog);
 
-		next(quickStartDialog);
+        next(quickStartDialog);
 
-		pickDefaultTestsuite(quickStartDialog);
+        pickDefaultTestsuite(quickStartDialog);
 
-		next(quickStartDialog);
+        next(quickStartDialog);
 
-		useConfigTemplate(quickStartDialog);
+        useConfigTemplate(quickStartDialog);
 
-		next(quickStartDialog);
-	}
+        next(quickStartDialog);
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse7.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse7.java
@@ -1,0 +1,61 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Browse;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public class Browse7 extends Browse {
+
+	public static void main(String[] args) {
+		JUnitCore.main("com.sun.javatest.tests.Browse.Browse7");
+	}
+
+	@Test
+	public void testBrowse7() {
+		browseTestsuite(quickStartDialog);
+
+		next(quickStartDialog);
+
+		pickDefaultTestsuite(quickStartDialog);
+
+		next(quickStartDialog);
+
+		useConfigTemplate(quickStartDialog);
+
+		next(quickStartDialog);
+
+		startConfigEditor(quickStartDialog);
+
+		finish(quickStartDialog, true);
+
+		pickWorkDir(mainFrame);
+
+		new JDialogOperator(mainFrame, "Configuration Editor");
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse7.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse7.java
@@ -32,30 +32,30 @@ import org.netbeans.jemmy.operators.JDialogOperator;
 
 public class Browse7 extends Browse {
 
-	public static void main(String[] args) {
-		JUnitCore.main("com.sun.javatest.tests.Browse.Browse7");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("com.sun.javatest.tests.Browse.Browse7");
+    }
 
-	@Test
-	public void testBrowse7() {
-		browseTestsuite(quickStartDialog);
+    @Test
+    public void testBrowse7() {
+        browseTestsuite(quickStartDialog);
 
-		next(quickStartDialog);
+        next(quickStartDialog);
 
-		pickDefaultTestsuite(quickStartDialog);
+        pickDefaultTestsuite(quickStartDialog);
 
-		next(quickStartDialog);
+        next(quickStartDialog);
 
-		useConfigTemplate(quickStartDialog);
+        useConfigTemplate(quickStartDialog);
 
-		next(quickStartDialog);
+        next(quickStartDialog);
 
-		startConfigEditor(quickStartDialog);
+        startConfigEditor(quickStartDialog);
 
-		finish(quickStartDialog, true);
+        finish(quickStartDialog, true);
 
-		pickWorkDir(mainFrame);
+        pickWorkDir(mainFrame);
 
-		new JDialogOperator(mainFrame, "Configuration Editor");
-	}
+        new JDialogOperator(mainFrame, "Configuration Editor");
+    }
 }


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature test scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.Browse3.java
2.Browse4.java
3.Browse7.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903074](https://bugs.openjdk.java.net/browse/CODETOOLS-7903074): Feature Tests - Adding three JavaTest GUI legacy automated feature test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/jtharness pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/18.diff">https://git.openjdk.java.net/jtharness/pull/18.diff</a>

</details>
