### PR TITLE
7903079: Feature Tests - Adding six JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit6.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit6.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_Edit;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_Edit6 extends Test {
+
+    public void testImpl() throws Exception {
+        mainFrame = new JTFrame(true);
+
+        // Open default test suite
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+        // load configuration
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.CONFIG_NAME, false);
+
+        ConfigDialog config = configuration.openByKey();
+
+        // Push Done button on configuration editor
+        config.pushDoneConfigEditor();
+
+        // Verify that the Done button should dismiss the editor dialog box.
+        if (config.getConfigDialog().isVisible()) {
+            errors.add("Config editor is not closed after clicking on Done button on configuration editor");
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "This test case verifies that Done button in the configuration editor will finish all the questions and dismiss the editor.";
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit6.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit6.java
@@ -39,7 +39,7 @@ public class Config_Edit6 extends Test {
 
         // Open default test suite
         mainFrame.openDefaultTestSuite();
-        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        mainFrame.createWorkDirectoryInTemp();
 
         // load configuration
         Configuration configuration = mainFrame.getConfiguration();

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit7.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit7.java
@@ -1,0 +1,112 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Edit;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import javax.swing.JTextField;
+
+import jthtest.Tools;
+
+public class Config_Edit7 extends Config_Edit {
+    public static void main(String args[]) {
+        JUnitCore.main("jthtest.gui.Config_Edit.Config_Edit7");
+    }
+
+    @Test
+    public void testConfig_Edit7() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+        // Start Java Test application with -newDesktop
+        startJavatestNewDesktop();
+
+        // get the reference of mainframe
+        JFrameOperator mainFrame = findMainFrame();
+
+        // Open default test suite
+        openTestSuite(mainFrame);
+
+        // Create work directory
+        createWorkDirInTemp(mainFrame);
+
+        // Load existing configuration file
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+        waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+        openConfigCreation(mainFrame);
+        JDialogOperator config = findConfigEditor(mainFrame);
+
+        // Push next button on configuration editor
+        pushNextConfigEditor(config);
+        new JTextFieldOperator(config, new NameComponentChooser("str.txt")).typeText("some_jti");
+
+        // Click on Done button
+        pushDoneConfigEditor(config);
+
+        // configuration editor will bring up a Save Configuration file chooser.
+        saveConfig();
+
+        // Bring up configuration editor by doing Ctrl-E
+        openConfigDialogByKey(mainFrame);
+
+        // Verify that the name of the jti file should be displayed.
+        if (!findConfigEditor(mainFrame).getTitle().contains("some_jti")) {
+            File f = new File(LOCAL_PATH + "jt_gui_test_temp_some_jti-this_file_will_be_deleted.jti");
+            f.delete();
+            throw new JemmyException("Wrong jti filename in config editor: " + findConfigEditor(mainFrame).getTitle());
+        }
+        File f = new File(LOCAL_PATH + "jt_gui_test_temp_some_jti-this_file_will_be_deleted.jti");
+        f.delete();
+    }
+
+    private void saveConfig() {
+        File f = new File(LOCAL_PATH + "jt_gui_test_temp_some_jti-this_file_will_be_deleted.jti");
+        if (f.exists())
+            f.delete();
+        JDialogOperator save = new JDialogOperator(getExecResource("ce.okToClose.title"));
+        new JButtonOperator(save, "Ok").push();
+        save = new JDialogOperator(getExecResource("ce.save.title"));
+        JTextFieldOperator tf;
+
+        tf = new JTextFieldOperator(
+                (JTextField) Tools.getComponent(save, new String[] { "Folder name:", "File name:" }));
+        tf.enterText("jt_gui_test_temp_some_jti-this_file_will_be_deleted");
+    }
+
+    public String getDescription() {
+        return "This test case verifies that Done button in the an empty configuration editor will bring up a Save Configuration file chooser.";
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load.java
@@ -1,0 +1,34 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Load;
+
+import jthtest.ConfigTools;
+
+public class Config_Load extends ConfigTools {
+
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load1.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load1.java
@@ -1,0 +1,68 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Load;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class Config_Load1 extends Config_Load {
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Config_Load.Config_Load1");
+    }
+
+    @Test
+    public void testConfig_Load1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+        // Start Java Test application with -newDesktop
+        startJavatestNewDesktop();
+
+        // get the reference of mainframe
+        JFrameOperator mainFrame = findMainFrame();
+
+        // Close Quick Start
+        closeQS(mainFrame);
+
+        // Open default test suite
+        openTestSuite(mainFrame);
+
+        // Create work directory
+        createWorkDirInTemp(mainFrame);
+
+        // Verify that file chooser should be displayed for loading an existing jti
+        // file.
+        openLoadConfigDialogByMenu(mainFrame);
+    }
+
+        // TestCase Description
+        public String getDescription() {
+            return "This test case verifies that Load button under configure menu will bring up a file chooser to select a jti file to be used.";
+        }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load2.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load2.java
@@ -1,0 +1,82 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Load;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class Config_Load2 extends Config_Load {
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Config_Load.Config_Load2");
+    }
+
+    @Test
+    public void testConfig_Load2() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+        // Start Java Test application with -newDesktop
+        startJavatestNewDesktop();
+
+        // get the reference of mainframe
+        JFrameOperator mainFrame = findMainFrame();
+
+        // Close Quick Start
+        closeQS(mainFrame);
+
+        // Open default test suite
+        openTestSuite(mainFrame);
+
+        // Create work directory
+        createWorkDirInTemp(mainFrame);
+
+        JDialogOperator fileChooser = openLoadConfigDialogByMenu(mainFrame);
+        openConfigFile(fileChooser, CONFIG_NAME);
+
+        if (!new JTextFieldOperator(mainFrame, new NameComponentChooser("bcc.Configuration")).getText()
+                .equals(CONFIG_NAME)) {
+            throw new JemmyException("Configuration file wasn't opened");
+        }
+
+        // Bring up configuration editor by doing Ctrl-E
+        openConfigDialogByKey(mainFrame);
+
+        // Verify that the existing jti file should be displayed.
+        findConfigEditor(mainFrame);
+    }
+
+    // TestCase Description
+    public String getDescription() {
+        return "This test case verifies that Load button under configure menu will bring up a configuration with a valid jti file.";
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load3.java
@@ -1,0 +1,71 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Load;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class Config_Load3 extends Config_Load {
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Config_Load.Config_Load3");
+    }
+
+    @Test
+    public void testConfig_Load3() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+        // Start Java Test application with -newDesktop
+        startJavatestNewDesktop();
+
+        // get the reference of mainframe
+        JFrameOperator mainFrame = findMainFrame();
+
+        // Close Quick Start
+        closeQS(mainFrame);
+
+        // Open default test suite
+        openTestSuite(mainFrame);
+
+        // Create work directory
+        createWorkDirInTemp(mainFrame);
+
+        JDialogOperator fileChooser = openLoadConfigDialogByMenu(mainFrame);
+        openConfigFile(fileChooser, "democonfig_another_suite.jti");
+
+        // Verify under configure menu will generate an error for an invalid jti file.
+        new JDialogOperator(WINDOWNAME + " Harness: Error");
+    }
+
+       // TestCase Description
+        public String getDescription() {
+            return "This test case verifies that Load button under configure menu will generate an error for an invalid jti file.";
+        }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load4.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load4.java
@@ -1,0 +1,96 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Load;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Config_Edit.Config_Edit;
+
+public class Config_Load4 extends Config_Load {
+    private JFrameOperator mainFrame;
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Config_Load.Config_Load4");
+    }
+
+    @Test
+    public void testConfig_Load4() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+        // Start Java Test application with -newDesktop
+        startJavatestNewDesktop();
+        mainFrame = findMainFrame();
+
+        // Open default test suite
+        openTestSuite(mainFrame);
+
+        // Create work directory
+        createWorkDirInTemp(mainFrame);
+
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+        Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+        // Bring up Edit configuration by doing Ctrl-E
+        openConfigDialogByKey(mainFrame);
+
+        // Push Done button on configuration editor
+        pushDoneConfigEditor(findConfigEditor(mainFrame));
+
+        // Bring up Load configuration under File menu and select a new jti file.
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), SECOND_CONFIG_NAME);
+        Config_Edit.waitForConfigurationLoading(mainFrame, SECOND_CONFIG_NAME);
+
+        // Bring up Edit configuration by doing Ctrl-E
+        openConfigDialogByKey(mainFrame);
+
+        // Verify that the new config file will be displayed.
+        if (!verifyOpeningNewConfigFile()) {
+            throw new JemmyException("Old config is shown in config editor");
+        }
+    }
+
+    private boolean verifyOpeningNewConfigFile() {
+        JDialogOperator config = findConfigEditor(mainFrame);
+        JListOperator list = new JListOperator(config);
+        list.selectItem(1);
+        return new JTextFieldOperator(config, new NameComponentChooser("str.txt")).getText().equals(SECOND_CONFIG_NAME);
+    }
+
+    // TestCase Description
+    public String getDescription() {
+        return "This test case verifies that Load button under configure menu will display the new config if the config editor is already open.";
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1. Config_Edit6
2. Config_Edit7
3. Config_Load1
4. Config_Load2
5. Config_Load3
6. Config_Load4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903079](https://bugs.openjdk.java.net/browse/CODETOOLS-7903079): Feature Tests - Adding six JavaTest GUI legacy automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/jtharness pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/20.diff">https://git.openjdk.java.net/jtharness/pull/20.diff</a>

</details>
