### PR TITLE
7903076: Feature Tests - Adding five JavaTest GUI legacy automated feature test scripts

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -420,6 +420,7 @@ harness-variety=Full Bundle
     <target name="compile-javatest.help" depends="compile-javatest.help.main,compile-javatestAgent.help"/>
 
     <target name="compile.resources" depends="stamp, generate.release.file">
+    	<property name="gui-tests" value="gui-tests/src/gui/testsuite_src/src"/>
         <copy todir="${build.classes}">
             <fileset dir="${src.dir}">
                 <patternset refid="interview.resources"/>
@@ -430,6 +431,8 @@ harness-variety=Full Bundle
         <buildinfo/>
         <copy file="${src.dir}/com/sun/javatest/tool/i18n.properties"
               tofile="${build.classes}/com/sun/javatest/tool/i18n_fr.properties"/>
+    	<copy file="${gui-tests}/com/sun/demots/i18n.properties"
+    	      tofile="${build.classes}/com/sun/javatest/tool/i18n_jck.properties"/>
         <mkdir dir="${build.classes}/META-INF/services"/>
         <copy file="${build.dir}/JavaTest.cmdMgrs.lst" tofile="${build.classes}/META-INF/services/com.sun.javatest.tool.CommandManager.lst"/>
         <copy file="${build.dir}/JavaTest.toolMgrs.lst" tofile="${build.classes}/META-INF/services/com.sun.javatest.tool.ToolManager.lst"/>

--- a/gui-tests/src/gui/data/demotemplate_incomplete.jtm
+++ b/gui-tests/src/gui/data/demotemplate_incomplete.jtm
@@ -1,0 +1,50 @@
+#
+# $Id$
+#
+#
+# Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+#JT Harness Configuration Interview
+#Fri Jul 10 21:01:23 BST 2009
+DESCRIPTION=demo template
+INTERVIEW=com.sun.demots.DemoTSInterview
+IS_TEMPLATE=true
+LOCALE=ru_RU
+NAME=demotemplate
+QUESTION=demoTS.epilog
+demoTS.cmdType=otherVM
+demoTS.concurrency.concurrency=1
+demoTS.desc=demo template
+demoTS.excludeList.latestAutoCheck=No
+demoTS.excludeList.latestAutoCheckInterval=7
+demoTS.excludeList.latestAutoCheckMode=everyXDays
+demoTS.excludeList.needExcludeList=No
+demoTS.keywords.keywords.mode=expr
+demoTS.keywords.needKeywords=No
+demoTS.name=demotemplate
+demoTS.priorStatus.needStatus=No
+demoTS.priorStatus.status=
+demoTS.tests.needTests=No
+demoTS.tests.tests=
+demoTS.tests.treeOrFile=tree

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse5.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse5.java
@@ -33,40 +33,40 @@ import junit.framework.Assert;
 
 public class Browse5 extends Browse {
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.Browse.Browse5");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Browse.Browse5");
+    }
 
-	@Test
-	public void test_incomplete_configuration_template() {
+    @Test
+    public void test_incomplete_configuration_template() {
 
-		// click on Browse the Test Suite Radio button
-		browseTestsuite(quickStartDialog);
+        // click on Browse the Test Suite Radio button
+        browseTestsuite(quickStartDialog);
 
-		// click on next button
-		next(quickStartDialog);
+        // click on next button
+        next(quickStartDialog);
 
-		// Select the test suite
-		pickDefaultTestsuite(quickStartDialog);
+        // Select the test suite
+        pickDefaultTestsuite(quickStartDialog);
 
-		// Click on next button
-		next(quickStartDialog);
+        // Click on next button
+        next(quickStartDialog);
 
-		// Select the incomplete configuration template
-		useIncompleteConfigTemplate(quickStartDialog);
+        // Select the incomplete configuration template
+        useIncompleteConfigTemplate(quickStartDialog);
 
-		// Click on next button
-		next(quickStartDialog);
+        // Click on next button
+        next(quickStartDialog);
 
-		Assert.assertEquals("The text should specify that the configuration is incomplete",
-				getJckResource("qsw.end.needEditor"), getTextArea(quickStartDialog));
+        Assert.assertEquals("The text should specify that the configuration is incomplete",
+                getJckResource("qsw.end.needEditor"), getTextArea(quickStartDialog));
 
-		Assert.assertEquals("Almost done text should be clear and easy to understand", getJckResource("qsw.end.hd"),
-				getTextField(quickStartDialog));
-	}
+        Assert.assertEquals("Almost done text should be clear and easy to understand", getJckResource("qsw.end.hd"),
+                getTextField(quickStartDialog));
+    }
 
-	// TestCase Description
-	public String getDescription() {
-		return "This test case verifies that using an incomplete configuration template file an error will be generated.";
-	}
+    // TestCase Description
+    public String getDescription() {
+        return "This test case verifies that using an incomplete configuration template file an error will be generated.";
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse5.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse5.java
@@ -1,0 +1,72 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Browse;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+import junit.framework.Assert;
+
+public class Browse5 extends Browse {
+
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.Browse.Browse5");
+	}
+
+	@Test
+	public void test_incomplete_configuration_template() {
+
+		// click on Browse the Test Suite Radio button
+		browseTestsuite(quickStartDialog);
+
+		// click on next button
+		next(quickStartDialog);
+
+		// Select the test suite
+		pickDefaultTestsuite(quickStartDialog);
+
+		// Click on next button
+		next(quickStartDialog);
+
+		// Select the incomplete configuration template
+		useIncompleteConfigTemplate(quickStartDialog);
+
+		// Click on next button
+		next(quickStartDialog);
+
+		Assert.assertEquals("The text should specify that the configuration is incomplete",
+				getJckResource("qsw.end.needEditor"), getTextArea(quickStartDialog));
+
+		Assert.assertEquals("Almost done text should be clear and easy to understand", getJckResource("qsw.end.hd"),
+				getTextField(quickStartDialog));
+	}
+
+	// TestCase Description
+	public String getDescription() {
+		return "This test case verifies that using an incomplete configuration template file an error will be generated.";
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse8.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse8.java
@@ -1,0 +1,74 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Browse;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+public class Browse8 extends Browse {
+
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.Browse.Browse8");
+	}
+
+	@Test
+	public void test_correct_numbers_shown_after_testsuite_loaded() {
+
+		// click on Browse the Test Suite Radio button
+		browseTestsuite(quickStartDialog);
+
+		// click on next button
+		next(quickStartDialog);
+
+		// Select the test suite
+		pickDefaultTestsuite(quickStartDialog);
+
+		// click on next button
+		next(quickStartDialog);
+
+		// Select the complete configuration template
+		useConfigTemplate(quickStartDialog);
+
+		// click on next button
+		next(quickStartDialog);
+
+		// start configuration editor
+		startConfigEditor(quickStartDialog);
+
+		// click on finish button
+		finish(quickStartDialog, false);
+
+		// verify that the correct numbers are shown in the right panel
+		checkCounters(mainFrame, new int[] { 0, 0, 0, 22, 22, 0, 22 });
+
+	}
+
+	// TestCase Description
+	public String getDescription() {
+		return "This test case verifies that the correct numbers will be shown in the right panel after loading a test suite with complete configuration.";
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/Browse/Browse8.java
+++ b/gui-tests/src/gui/src/jthtest/Browse/Browse8.java
@@ -31,44 +31,44 @@ import org.junit.runner.JUnitCore;
 
 public class Browse8 extends Browse {
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.Browse.Browse8");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Browse.Browse8");
+    }
 
-	@Test
-	public void test_correct_numbers_shown_after_testsuite_loaded() {
+    @Test
+    public void test_correct_numbers_shown_after_testsuite_loaded() {
 
-		// click on Browse the Test Suite Radio button
-		browseTestsuite(quickStartDialog);
+        // click on Browse the Test Suite Radio button
+        browseTestsuite(quickStartDialog);
 
-		// click on next button
-		next(quickStartDialog);
+        // click on next button
+        next(quickStartDialog);
 
-		// Select the test suite
-		pickDefaultTestsuite(quickStartDialog);
+        // Select the test suite
+        pickDefaultTestsuite(quickStartDialog);
 
-		// click on next button
-		next(quickStartDialog);
+        // click on next button
+        next(quickStartDialog);
 
-		// Select the complete configuration template
-		useConfigTemplate(quickStartDialog);
+        // Select the complete configuration template
+        useConfigTemplate(quickStartDialog);
 
-		// click on next button
-		next(quickStartDialog);
+        // click on next button
+        next(quickStartDialog);
 
-		// start configuration editor
-		startConfigEditor(quickStartDialog);
+        // start configuration editor
+        startConfigEditor(quickStartDialog);
 
-		// click on finish button
-		finish(quickStartDialog, false);
+        // click on finish button
+        finish(quickStartDialog, false);
 
-		// verify that the correct numbers are shown in the right panel
-		checkCounters(mainFrame, new int[] { 0, 0, 0, 22, 22, 0, 22 });
+        // verify that the correct numbers are shown in the right panel
+        checkCounters(mainFrame, new int[] { 0, 0, 0, 22, 22, 0, 22 });
 
-	}
+    }
 
-	// TestCase Description
-	public String getDescription() {
-		return "This test case verifies that the correct numbers will be shown in the right panel after loading a test suite with complete configuration.";
-	}
+    // TestCase Description
+    public String getDescription() {
+        return "This test case verifies that the correct numbers will be shown in the right panel after loading a test suite with complete configuration.";
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit3.java
@@ -36,7 +36,6 @@ import jthtest.tools.JTFrame;
 
 public class Config_Edit3 extends Test {
 
-    @org.junit.Test
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
         mainFrame = new JTFrame(true);

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit3.java
@@ -36,35 +36,35 @@ import jthtest.tools.JTFrame;
 
 public class Config_Edit3 extends Test {
 
-	@org.junit.Test
-	public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+    @org.junit.Test
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-		mainFrame = new JTFrame(true);
+        mainFrame = new JTFrame(true);
 
-		// Open default test suite, create workdirectory and load configuration
-		mainFrame.openDefaultTestSuite();
-		addUsedFile(mainFrame.createWorkDirectoryInTemp());
-		Configuration conf = mainFrame.getConfiguration();
-		conf.load(CONFIG_NAME, true);
+        // Open default test suite, create workdirectory and load configuration
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration conf = mainFrame.getConfiguration();
+        conf.load(CONFIG_NAME, true);
 
-		// push back button on configuration editor and verify back button is disabled
-		ConfigDialog cd = conf.openByKey();
-		cd.pushBackConfigEditor();
-		if (cd.getBackButton().isEnabled()) {
-			errors.add("Back button is enabled while unexpected");
-		}
+        // push back button on configuration editor and verify back button is disabled
+        ConfigDialog cd = conf.openByKey();
+        cd.pushBackConfigEditor();
+        if (cd.getBackButton().isEnabled()) {
+            errors.add("Back button is enabled while unexpected");
+        }
 
-		// push next and back buttons and verify that the configuration editor will go
-		// back to previous question
-		cd.pushNextConfigEditor();
-		cd.pushBackConfigEditor();
-		if (!cd.isSelectedIndex(0)) {
-			errors.add("After back button pushing list selection is not on first question");
-		}
-	}
+        // push next and back buttons and verify that the configuration editor will go
+        // back to previous question
+        cd.pushNextConfigEditor();
+        cd.pushBackConfigEditor();
+        if (!cd.isSelectedIndex(0)) {
+            errors.add("After back button pushing list selection is not on first question");
+        }
+    }
 
-	// TestCase Description
-	public String getDescription() {
-		return "This test case verifies that Back button in the configuration editor will go back to the previous question.";
-	}
+    // TestCase Description
+    public String getDescription() {
+        return "This test case verifies that Back button in the configuration editor will go back to the previous question.";
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit3.java
@@ -1,0 +1,70 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Edit;
+
+import java.lang.reflect.InvocationTargetException;
+
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_Edit3 extends Test {
+
+	@org.junit.Test
+	public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+		mainFrame = new JTFrame(true);
+
+		// Open default test suite, create workdirectory and load configuration
+		mainFrame.openDefaultTestSuite();
+		addUsedFile(mainFrame.createWorkDirectoryInTemp());
+		Configuration conf = mainFrame.getConfiguration();
+		conf.load(CONFIG_NAME, true);
+
+		// push back button on configuration editor and verify back button is disabled
+		ConfigDialog cd = conf.openByKey();
+		cd.pushBackConfigEditor();
+		if (cd.getBackButton().isEnabled()) {
+			errors.add("Back button is enabled while unexpected");
+		}
+
+		// push next and back buttons and verify that the configuration editor will go
+		// back to previous question
+		cd.pushNextConfigEditor();
+		cd.pushBackConfigEditor();
+		if (!cd.isSelectedIndex(0)) {
+			errors.add("After back button pushing list selection is not on first question");
+		}
+	}
+
+	// TestCase Description
+	public String getDescription() {
+		return "This test case verifies that Back button in the configuration editor will go back to the previous question.";
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit3.java
@@ -36,7 +36,7 @@ import jthtest.tools.JTFrame;
 
 public class Config_Edit3 extends Test {
 
-    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+   public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
         mainFrame = new JTFrame(true);
 

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit4.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit4.java
@@ -37,38 +37,38 @@ import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JListOperator;
 
 public class Config_Edit4 extends Config_Edit {
-	public static void main(String args[]) {
-		JUnitCore.main("jthtest.gui.Config_Edit.Config_Edit4");
-	}
+    public static void main(String args[]) {
+        JUnitCore.main("jthtest.gui.Config_Edit.Config_Edit4");
+    }
 
-	@Test
-	public void test_next_button_config_editor_next_question()
-			throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+    @Test
+    public void test_next_button_config_editor_next_question()
+            throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-		// start javatest with -newDesktop option
-		startJavatestNewDesktop();
-		JFrameOperator mainFrame = findMainFrame();
+        // start javatest with -newDesktop option
+        startJavatestNewDesktop();
+        JFrameOperator mainFrame = findMainFrame();
 
-		// Open test suite and load configuration
-		openTestSuite(mainFrame);
-		createWorkDirInTemp(mainFrame);
-		openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
-		waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+        // Open test suite and load configuration
+        openTestSuite(mainFrame);
+        createWorkDirInTemp(mainFrame);
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+        waitForConfigurationLoading(mainFrame, CONFIG_NAME);
 
-		openConfigDialogByKey(mainFrame);
-		JDialogOperator config = findConfigEditor(mainFrame);
+        openConfigDialogByKey(mainFrame);
+        JDialogOperator config = findConfigEditor(mainFrame);
 
-		// push next button on configuration editor
-		pushNextConfigEditor(config);
+        // push next button on configuration editor
+        pushNextConfigEditor(config);
 
-		// verify that Next button in the configuration editor will go forward to the
-		// next question
-		if (!new JListOperator(config).isSelectedIndex(2))
-			throw new JemmyException("After next button pushing list selection is not on third page");
-	}
+        // verify that Next button in the configuration editor will go forward to the
+        // next question
+        if (!new JListOperator(config).isSelectedIndex(2))
+            throw new JemmyException("After next button pushing list selection is not on third page");
+    }
 
-	// TestCase Description
-	public String getDescription() {
-		return "This test case verifies that Next button in the configuration editor will go forward to the next question.";
-	}
+    // TestCase Description
+    public String getDescription() {
+        return "This test case verifies that Next button in the configuration editor will go forward to the next question.";
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit4.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit4.java
@@ -1,0 +1,74 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Edit;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+
+public class Config_Edit4 extends Config_Edit {
+	public static void main(String args[]) {
+		JUnitCore.main("jthtest.gui.Config_Edit.Config_Edit4");
+	}
+
+	@Test
+	public void test_next_button_config_editor_next_question()
+			throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+		// start javatest with -newDesktop option
+		startJavatestNewDesktop();
+		JFrameOperator mainFrame = findMainFrame();
+
+		// Open test suite and load configuration
+		openTestSuite(mainFrame);
+		createWorkDirInTemp(mainFrame);
+		openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+		waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+		openConfigDialogByKey(mainFrame);
+		JDialogOperator config = findConfigEditor(mainFrame);
+
+		// push next button on configuration editor
+		pushNextConfigEditor(config);
+
+		// verify that Next button in the configuration editor will go forward to the
+		// next question
+		if (!new JListOperator(config).isSelectedIndex(2))
+			throw new JemmyException("After next button pushing list selection is not on third page");
+	}
+
+	// TestCase Description
+	public String getDescription() {
+		return "This test case verifies that Next button in the configuration editor will go forward to the next question.";
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit5.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit5.java
@@ -36,33 +36,33 @@ import jthtest.tools.JTFrame;
 
 public class Config_Edit5 extends Test {
 
-	@org.junit.Test
-	public void testImpl() throws Exception {
-		mainFrame = new JTFrame(true);
+    @org.junit.Test
+    public void testImpl() throws Exception {
+        mainFrame = new JTFrame(true);
 
-		// Open default test suite
-		mainFrame.openDefaultTestSuite();
-		addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        // Open default test suite
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
 
-		// load configuration
-		Configuration configuration = mainFrame.getConfiguration();
-		configuration.load(Tools.CONFIG_NAME, true);
+        // load configuration
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.CONFIG_NAME, true);
 
-		// push last button on the configuration editor
-		ConfigDialog dialog = configuration.openByKey();
-		dialog.pushLastConfigEditor();
-		JListOperator list = new JListOperator(dialog.getConfigDialog());
+        // push last button on the configuration editor
+        ConfigDialog dialog = configuration.openByKey();
+        dialog.pushLastConfigEditor();
+        JListOperator list = new JListOperator(dialog.getConfigDialog());
 
-		// verifies that Last button in the configuration editor will go to the last
-		// question.
-		if (list.getSelectedIndex() != list.getModel().getSize() - 1) {
-			errors.add("Selected element (" + list.getSelectedIndex() + ") is not the last ("
-					+ (list.getModel().getSize() - 1) + ") after last button pushing");
-		}
-	}
+        // verifies that Last button in the configuration editor will go to the last
+        // question.
+        if (list.getSelectedIndex() != list.getModel().getSize() - 1) {
+            errors.add("Selected element (" + list.getSelectedIndex() + ") is not the last ("
+                    + (list.getModel().getSize() - 1) + ") after last button pushing");
+        }
+    }
 
-	// TestCase Description
-	public String getDescription() {
-		return "This test case verifies that Last button in the configuration editor will go to the last question.";
-	}
+    // TestCase Description
+    public String getDescription() {
+        return "This test case verifies that Last button in the configuration editor will go to the last question.";
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit5.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit5.java
@@ -36,7 +36,6 @@ import jthtest.tools.JTFrame;
 
 public class Config_Edit5 extends Test {
 
-    @org.junit.Test
     public void testImpl() throws Exception {
         mainFrame = new JTFrame(true);
 

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit5.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit5.java
@@ -1,0 +1,68 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_Edit;
+
+import org.netbeans.jemmy.operators.JListOperator;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_Edit5 extends Test {
+
+	@org.junit.Test
+	public void testImpl() throws Exception {
+		mainFrame = new JTFrame(true);
+
+		// Open default test suite
+		mainFrame.openDefaultTestSuite();
+		addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+		// load configuration
+		Configuration configuration = mainFrame.getConfiguration();
+		configuration.load(Tools.CONFIG_NAME, true);
+
+		// push last button on the configuration editor
+		ConfigDialog dialog = configuration.openByKey();
+		dialog.pushLastConfigEditor();
+		JListOperator list = new JListOperator(dialog.getConfigDialog());
+
+		// verifies that Last button in the configuration editor will go to the last
+		// question.
+		if (list.getSelectedIndex() != list.getModel().getSize() - 1) {
+			errors.add("Selected element (" + list.getSelectedIndex() + ") is not the last ("
+					+ (list.getModel().getSize() - 1) + ") after last button pushing");
+		}
+	}
+
+	// TestCase Description
+	public String getDescription() {
+		return "This test case verifies that Last button in the configuration editor will go to the last question.";
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/Tools.java
+++ b/gui-tests/src/gui/src/jthtest/Tools.java
@@ -28,25 +28,59 @@
 
 package jthtest;
 
-import com.sun.javatest.TestResult;
-import jthtest.menu.Menu;
-import org.junit.After;
-import org.netbeans.jemmy.*;
-import org.netbeans.jemmy.operators.*;
-import org.netbeans.jemmy.operators.Operator.StringComparator;
-import org.netbeans.jemmy.util.NameComponentChooser;
-
-import javax.swing.*;
-import java.awt.*;
-import java.io.*;
+import java.awt.Component;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.*;
+import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.junit.After;
+import org.netbeans.jemmy.ClassReference;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.JemmyProperties;
+import org.netbeans.jemmy.TestOut;
+import org.netbeans.jemmy.TimeoutExpiredException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JCheckBoxOperator;
+import org.netbeans.jemmy.operators.JComboBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JLabelOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTabbedPaneOperator;
+import org.netbeans.jemmy.operators.JTableOperator;
+import org.netbeans.jemmy.operators.JTextAreaOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.operators.JTreeOperator;
+import org.netbeans.jemmy.operators.Operator.StringComparator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JTextField;
+
+import com.sun.javatest.TestResult;
+
+import jthtest.menu.Menu;
 
 public class Tools {
 
@@ -60,6 +94,8 @@ public class Tools {
     public static final String TEST_SUITE_NAME = "demots";
     @Deprecated
     public static final String TEMPLATE_NAME = "demotemplate.jtm";
+    @Deprecated
+    public static final String INCOMPLETE_TEMPLATE_NAME = "demotemplate_incomplete.jtm";
     @Deprecated
     public static final String REPORT_NAME = "demoreport";
     @Deprecated
@@ -84,12 +120,14 @@ public class Tools {
     public static String USER_HOME_PATH;
     private static ResourceBundle i18nExecResources;    // reading resources exacly from the javatest.jar to not to do mistakes in element's names
     private static ResourceBundle i18nToolResources;  // reading resources of dialog boxes exacly from the javatest.jar to not to do mistakes in element's names
+    private static ResourceBundle i18nJckResources;
     private static LinkedList<File> usedFiles = new LinkedList<File>();
 
     static {
         JemmyProperties.getCurrentTimeouts().setTimeout("ComponentOperator.WaitComponentTimeout", MAX_WAIT_TIME);
         JemmyProperties.setCurrentOutput(new TestOut(null, (PrintWriter) null, null));
-
+        
+        i18nJckResources  = ResourceBundle.getBundle("com.sun.javatest.tool.i18n_jck");
         i18nExecResources = ResourceBundle.getBundle("com.sun.javatest.exec.i18n");
         i18nToolResources = ResourceBundle.getBundle("com.sun.javatest.tool.i18n");
 
@@ -151,7 +189,11 @@ public class Tools {
     public static String getToolResource(String key) {
         return i18nToolResources.getString(key);
     }
-
+    
+    public static String getJckResource(String key) {
+        return i18nJckResources.getString(key);
+    }
+    
     // checks if panel is opened
     public static boolean checkPanel() {
         return true;
@@ -242,6 +284,16 @@ public class Tools {
         JLabelOperator label = new JLabelOperator(dialog, caption);
         return new JTextFieldOperator((JTextField) label.getLabelFor());
     }
+    
+	// gets JTextField in dialog by it's dialog name
+	public static String getTextField(JDialogOperator dialog) {
+		return new JTextFieldOperator(dialog, "").getText();
+	}
+
+	// gets JTextArea in dialog by it's dialog name
+	public static String getTextArea(JDialogOperator dialog) {
+		return new JTextAreaOperator(dialog, "").getText();
+	}
 
     public static JComponent getComponent(final JDialogOperator dialog, final String captions[]) {
         ComponentFinder threads[] = new ComponentFinder[captions.length];
@@ -359,6 +411,14 @@ public class Tools {
         new JRadioButtonOperator(quickStartDialog, getExecResource("qsw.cfg.template.rb")).push();
 
         getTextField(quickStartDialog, getExecResource("qsw.cfg.jtm.field.lbl")).typeText(TEMPLATE_NAME);
+    }
+    
+ // uses incomplete template config in QS
+    static public void useIncompleteConfigTemplate(JDialogOperator quickStartDialog) {
+
+        new JRadioButtonOperator(quickStartDialog, getExecResource("qsw.cfg.template.rb")).push();
+
+        getTextField(quickStartDialog, getExecResource("qsw.cfg.jtm.field.lbl")).typeText(INCOMPLETE_TEMPLATE_NAME);
     }
 
     // uses bad template config in QS

--- a/gui-tests/src/gui/src/jthtest/Tools.java
+++ b/gui-tests/src/gui/src/jthtest/Tools.java
@@ -126,7 +126,7 @@ public class Tools {
     static {
         JemmyProperties.getCurrentTimeouts().setTimeout("ComponentOperator.WaitComponentTimeout", MAX_WAIT_TIME);
         JemmyProperties.setCurrentOutput(new TestOut(null, (PrintWriter) null, null));
-        
+
         i18nJckResources  = ResourceBundle.getBundle("com.sun.javatest.tool.i18n_jck");
         i18nExecResources = ResourceBundle.getBundle("com.sun.javatest.exec.i18n");
         i18nToolResources = ResourceBundle.getBundle("com.sun.javatest.tool.i18n");
@@ -189,11 +189,11 @@ public class Tools {
     public static String getToolResource(String key) {
         return i18nToolResources.getString(key);
     }
-    
+
     public static String getJckResource(String key) {
         return i18nJckResources.getString(key);
     }
-    
+
     // checks if panel is opened
     public static boolean checkPanel() {
         return true;
@@ -284,16 +284,16 @@ public class Tools {
         JLabelOperator label = new JLabelOperator(dialog, caption);
         return new JTextFieldOperator((JTextField) label.getLabelFor());
     }
-    
-	// gets JTextField in dialog by it's dialog name
-	public static String getTextField(JDialogOperator dialog) {
-		return new JTextFieldOperator(dialog, "").getText();
-	}
 
-	// gets JTextArea in dialog by it's dialog name
-	public static String getTextArea(JDialogOperator dialog) {
-		return new JTextAreaOperator(dialog, "").getText();
-	}
+    // gets JTextField in dialog by it's dialog name
+    public static String getTextField(JDialogOperator dialog) {
+        return new JTextFieldOperator(dialog, "").getText();
+    }
+
+    // gets JTextArea in dialog by it's dialog name
+    public static String getTextArea(JDialogOperator dialog) {
+        return new JTextAreaOperator(dialog, "").getText();
+    }
 
     public static JComponent getComponent(final JDialogOperator dialog, final String captions[]) {
         ComponentFinder threads[] = new ComponentFinder[captions.length];
@@ -412,7 +412,7 @@ public class Tools {
 
         getTextField(quickStartDialog, getExecResource("qsw.cfg.jtm.field.lbl")).typeText(TEMPLATE_NAME);
     }
-    
+
  // uses incomplete template config in QS
     static public void useIncompleteConfigTemplate(JDialogOperator quickStartDialog) {
 

--- a/gui-tests/src/gui/testsuite_src/src/com/sun/demots/i18n.properties
+++ b/gui-tests/src/gui/testsuite_src/src/com/sun/demots/i18n.properties
@@ -71,3 +71,6 @@ DemoTSInterview.testVerboseLevel.text=Specify how verbose tests should be.
 DemoTSInterview.testVerboseLevel.low=Low
 DemoTSInterview.testVerboseLevel.medium=Medium
 DemoTSInterview.testVerboseLevel.high=High
+
+qsw.end.hd=Almost done ...
+qsw.end.needEditor=Before you can run tests, you must complete a configuration by using the Configuration Editor. You can open the Configuration Editor automatically by checking the box below. You can also open the Configuration Editor at any time from the Configure menu.


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.Browse5.java
2.Browse8.java
3.Config_Edit3.java
4.Config_Edit4.java
5.Config_Edit5.java

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903076](https://bugs.openjdk.java.net/browse/CODETOOLS-7903076): Feature Tests - Adding five JavaTest GUI legacy automated feature test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.java.net/jtharness pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/21.diff">https://git.openjdk.java.net/jtharness/pull/21.diff</a>

</details>
