### PR TITLE
7902698: Collision of zero timestamp as a special value with use in filesystems

### DIFF
--- a/src/com/sun/javatest/ExcludeListUpdateHandler.java
+++ b/src/com/sun/javatest/ExcludeListUpdateHandler.java
@@ -41,9 +41,9 @@ import java.net.URLConnection;
  */
 public class ExcludeListUpdateHandler {
     private File localFile;
-    private long localFileLastModified;
+    private long localFileLastModified = -1;
     private URL remoteURL;
-    private long remoteURLLastModified;
+    private long remoteURLLastModified = -1;
 
     /**
      * Create a handler for downloading exclude lists from a server.
@@ -78,7 +78,7 @@ public class ExcludeListUpdateHandler {
      * a problem determining the required information
      */
     public long getLocalFileLastModified() {
-        if (localFileLastModified == 0) {
+        if (localFileLastModified == -1) {
             localFileLastModified = localFile.lastModified();
         }
         return localFileLastModified;
@@ -102,7 +102,7 @@ public class ExcludeListUpdateHandler {
      * @throws IOException if there is a problem determining the information.
      */
     public long getRemoteURLLastModified() throws IOException {
-        if (remoteURLLastModified == 0) {
+        if (remoteURLLastModified == -1) {
             URLConnection c = remoteURL.openConnection();
             c.connect();
             remoteURLLastModified = c.getLastModified();

--- a/src/com/sun/javatest/InterviewParameters.java
+++ b/src/com/sun/javatest/InterviewParameters.java
@@ -47,6 +47,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.ResourceBundle;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -100,7 +101,7 @@ public abstract class InterviewParameters
     private File currFile;
     private boolean isTemplate;
     private String templatePath;
-    private long currFileLastModified = -1;
+    private OptionalLong currFileLastModified = OptionalLong.empty();
     private boolean currFileLoaded;
     private CustomPropagationController pc = new CustomPropagationController();
 
@@ -1126,10 +1127,10 @@ public abstract class InterviewParameters
         currFile = f;
         currFileLoaded = false;
         if (f != null) {
-            currFileLastModified = f.lastModified();
+            currFileLastModified = OptionalLong.of(f.lastModified());
         } else {
             // means: unknown; will likely a trigger a reload
-            currFileLastModified = -1;
+            currFileLastModified = OptionalLong.empty();
         }
     }
 
@@ -1209,7 +1210,7 @@ public abstract class InterviewParameters
 
         setEdited(false);
         currFile = file;
-        currFileLastModified = file.lastModified();
+        currFileLastModified = OptionalLong.of(file.lastModified());
         currFileLoaded = true;
         return checkForUpdates();
     }
@@ -1443,7 +1444,7 @@ public abstract class InterviewParameters
 
         setEdited(false);
         currFile = file;
-        currFileLastModified = file.lastModified();
+        currFileLastModified = OptionalLong.of(file.lastModified());
         currFileLoaded = true;
     }
 
@@ -1615,8 +1616,8 @@ public abstract class InterviewParameters
      */
     public boolean isFileNewer() {
         File f = getFile();
-        return f != null && f.exists() && ((currFileLastModified == -1)
-                || (f.lastModified() > currFileLastModified));
+        return f != null && f.exists() && (currFileLastModified.isEmpty()
+                || (f.lastModified() > currFileLastModified.getAsLong()));
     }
 
     /**

--- a/src/com/sun/javatest/InterviewParameters.java
+++ b/src/com/sun/javatest/InterviewParameters.java
@@ -100,7 +100,7 @@ public abstract class InterviewParameters
     private File currFile;
     private boolean isTemplate;
     private String templatePath;
-    private long currFileLastModified;
+    private long currFileLastModified = -1;
     private boolean currFileLoaded;
     private CustomPropagationController pc = new CustomPropagationController();
 
@@ -1129,7 +1129,7 @@ public abstract class InterviewParameters
             currFileLastModified = f.lastModified();
         } else {
             // means: unknown; will likely a trigger a reload
-            currFileLastModified = 0;
+            currFileLastModified = -1;
         }
     }
 
@@ -1615,7 +1615,7 @@ public abstract class InterviewParameters
      */
     public boolean isFileNewer() {
         File f = getFile();
-        return f != null && f.exists() && ((currFileLastModified == 0)
+        return f != null && f.exists() && ((currFileLastModified == -1)
                 || (f.lastModified() > currFileLastModified));
     }
 

--- a/src/com/sun/javatest/TRT_TreeNode.java
+++ b/src/com/sun/javatest/TRT_TreeNode.java
@@ -791,7 +791,7 @@ public class TRT_TreeNode implements TestResultTable.TreeNode {
 
         File thisDir = new File(TestResultTable.getRootRelativePath(this));
         long lmd = table.getLastModifiedTime(thisDir);
-        if (lastScanDate.isEmpty() || lmd <= lastScanDate.getAsLong()) {
+        if (lastScanDate.isPresent() && lmd <= lastScanDate.getAsLong()) {
             return;
         }
 
@@ -904,7 +904,7 @@ public class TRT_TreeNode implements TestResultTable.TreeNode {
 
             // may be less than if the custom finder starts to return a
             // bogus value - like zero or 1 for whatever reason
-            if (lastScanDate.isEmpty() || thisScanDate <= lastScanDate.getAsLong()) {
+            if (lastScanDate.isPresent() && thisScanDate <= lastScanDate.getAsLong()) {
                 return false;
             }
 

--- a/src/com/sun/javatest/TRT_TreeNode.java
+++ b/src/com/sun/javatest/TRT_TreeNode.java
@@ -63,7 +63,7 @@ public class TRT_TreeNode implements TestResultTable.TreeNode {
     private int counter;                // nodes below this point and including self
     private int[] childStats;
     private String name;                // basically the directory name, null means root node
-    private long lastScanDate;
+    private long lastScanDate = -1;
     /**
      * List of files that makeup the on-disk contents of this node.
      * These are probably HTML files with test descriptions in them.  The string is a
@@ -277,7 +277,7 @@ public class TRT_TreeNode implements TestResultTable.TreeNode {
     @Override
     public boolean isUpToDate() {
         // compare timestamp in the future
-        return lastScanDate != 0;
+        return lastScanDate >= 0;
     }
 
     /**
@@ -892,7 +892,7 @@ public class TRT_TreeNode implements TestResultTable.TreeNode {
      */
     public synchronized boolean refreshIfNeeded() {
         if (filesToScan != null ||
-                (table != null && table.isFinderScanSuppressed() && lastScanDate == 0)) {
+                (table != null && table.isFinderScanSuppressed() && !isUpToDate())) {
             //File thisDir = new File(getTestSuiteRootPathPrefix(),
             //              TestResultTable.getRootRelativePath(this));
             File thisDir = new File(TestResultTable.getRootRelativePath(this));


### PR DESCRIPTION
This fixes a bug when the timestamp of a test file is set to zero, since jtharness currently uses zero as a special value. See discussion in [CODETOOLS-7902698](https://bugs.openjdk.java.net/browse/CODETOOLS-7902698).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902698](https://bugs.openjdk.java.net/browse/CODETOOLS-7902698): Collision of zero timestamp as a special value with use in filesystems


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jtharness pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/22.diff">https://git.openjdk.java.net/jtharness/pull/22.diff</a>

</details>
