### PR TITLE
7903135: Correct license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ The GNU General Public License (GPL)
 Version 2, June 1991
 
 Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Everyone is permitted to copy and distribute verbatim copies of this license
 document, but changing it is not allowed.
@@ -287,8 +287,8 @@ pointer to where the full notice is found.
     more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc., 59
-    Temple Place, Suite 330, Boston, MA 02111-1307 USA
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -325,11 +325,11 @@ License instead of this License.
 
 "CLASSPATH" EXCEPTION TO THE GPL
 
-Certain source files distributed by Oracle are subject to
-the following clarification and special exception to the GPL, but only where
-Oracle has expressly included in the particular source file's header the words
-"Oracle designates this particular file as subject to the "Classpath" exception
-as provided by Oracle in the LICENSE file that accompanied this code."
+Certain source files distributed by Oracle America and/or its affiliates are
+subject to the following clarification and special exception to the GPL, but
+only where Oracle has expressly included in the particular source file's header
+the words "Oracle designates this particular file as subject to the "Classpath"
+exception as provided by Oracle in the LICENSE file that accompanied this code."
 
     Linking this library statically or dynamically with other modules is making
     a combined work based on this library.  Thus, the terms and conditions of

--- a/build/build.xml
+++ b/build/build.xml
@@ -180,6 +180,7 @@ harness-variety=Full Bundle
         <copy todir="${target.legal.dir}">
             <fileset dir="${legal.dir}"/>
         </copy>
+        <copy file="LICENSE" todir="${BUILD_DIR}/binaries"/>
 
         <property name="target.doc.dir" value="${BUILD_DIR}/binaries/doc"/>
         <mkdir dir="${target.doc.dir}"/>

--- a/doc/deliverables/ReleaseNotes-jtharness.html
+++ b/doc/deliverables/ReleaseNotes-jtharness.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!--
-  Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  
   This code is free software; you can redistribute it and/or modify it
@@ -492,8 +492,7 @@ Agent Monitor tool.</p>
 </div>
 <hr>
     
-<p class="copyright"><a href="../../legal/copyright.txt">Copyright</a> &copy; 2011, 2013, Oracle and/or its affiliates. All rights reserved. The JT Harness project is released under the <A
-HREF="legal/license.txt">GNU General Public License Version 2 (GPLv2)</A>.
+<p class="copyright"><a href="../../legal/copyright.txt">Copyright</a> &copy; 2011, 2022, Oracle and/or its affiliates. All rights reserved. The JT Harness project is released under the <A HREF="LICENSE">GNU General Public License Version 2 (GPLv2)</A>.
 </p>
 </body>
 </html>

--- a/legal/copyright.txt
+++ b/legal/copyright.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it

--- a/src/com/sun/javatest/TRT_TreeNode.java
+++ b/src/com/sun/javatest/TRT_TreeNode.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2001, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/com/sun/javatest/TRT_TreeNode.java
+++ b/src/com/sun/javatest/TRT_TreeNode.java
@@ -2,27 +2,27 @@
  * $Id$
  *
  * Copyright (c) 2001, 2012, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version
- * 2 only, as published by the Free Software Foundation.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License version 2 for more details (a copy is
- * included at /legal/license.txt).
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
  *
- * You should have received a copy of the GNU General Public License
- * version 2 along with this work; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa
- * Clara, CA 95054 or visit www.sun.com if you need additional
- * information or questions.
- *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package com.sun.javatest;

--- a/src/com/sun/javatest/stylesheet.css
+++ b/src/com/sun/javatest/stylesheet.css
@@ -2,26 +2,27 @@
   $Id$
 
   Copyright (c) 2006, 2009, Oracle and/or its affiliates. All rights reserved.
-  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License version
-  2 only, as published by the Free Software Foundation.
+  This code is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 only, as
+  published by the Free Software Foundation.  Oracle designates this
+  particular file as subject to the "Classpath" exception as provided
+  by Oracle in the LICENSE file that accompanied this code.
 
-  This program is distributed in the hope that it will be useful, but
-  WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  General Public License version 2 for more details (a copy is
-  included at /legal/license.txt).
+  This code is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+  version 2 for more details (a copy is included in the LICENSE file that
+  accompanied this code).
 
-  You should have received a copy of the GNU General Public License
-  version 2 along with this work; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  02110-1301 USA
+  You should have received a copy of the GNU General Public License version
+  2 along with this work; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
-  Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa
-  Clara, CA 95054 or visit www.sun.com if you need additional
-  information or questions.
+  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+  or visit www.oracle.com if you need additional information or have any
+  questions.
 -->
 
 <style type="text/css">

--- a/src/com/sun/javatest/stylesheet.css
+++ b/src/com/sun/javatest/stylesheet.css
@@ -1,7 +1,7 @@
 <!--
   $Id$
 
-  Copyright (c) 2006, 2009, Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
   This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The JT Harness repository doesn't have a LICENSE file.
It contains `legal/license.txt`.
We need to place a proper LICENSE file to the repository root.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903135](https://bugs.openjdk.java.net/browse/CODETOOLS-7903135): Correct license file


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 4ab6db7341bd656f2665288765ccb22e7a7b035d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jtharness pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/26.diff">https://git.openjdk.java.net/jtharness/pull/26.diff</a>

</details>
