### PR TITLE
7903153: Sanity Tests - Adding JavaTest GUI newly automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Config_Edit1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Config_Edit1.java
@@ -1,0 +1,130 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JTableOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.menu.Menu;
+
+public class Test_Config_Edit1 extends Config_Edit {
+    public static void main(String args[]) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_Config_Edit1");
+    }
+
+    /**
+     * This test case verifies that Next button in the configuration editor will go
+     * forward to the next question.
+     *
+     * @throws ClassNotFoundException
+     *
+     * @throws InvocationTargetException
+     *
+     * @throws NoSuchMethodException
+     */
+    @Test
+    public void test_next_button_config_editor_next_question()
+            throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        int interview_question_num = 1;
+        startJavatestNewDesktop();
+        JFrameOperator mainFrame = findMainFrame();
+
+        openTestSuite(mainFrame);
+        createWorkDirInTemp(mainFrame);
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+        waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+        JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+        jmbo.pushMenuNoBlock("Configure", "/");
+        Menu.getConfigure_NewConfigurationMenu(mainFrame).pushNoBlock();
+        JDialogOperator config = findConfigEditor(mainFrame);
+
+        JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+
+        while (interview_question_num <= 6) {
+            fillInterviewQuestion(configEditorDialog, interview_question_num);
+            pushNextConfigEditor(configEditorDialog);
+            interview_question_num++;
+        }
+
+        if (!new JListOperator(config).isSelectedIndex(new JListOperator(config).getSelectedIndex()))
+            throw new JemmyException("After next button pushing list selection is not on proper page");
+    }
+
+    public void fillInterviewQuestion(JDialogOperator config, int interview_question_num) {
+        ComponentChooser n = new NameComponentChooser("str.txt");
+        switch (interview_question_num) {
+        case 1:
+            return;
+        case 2:
+            JTextFieldOperator testName = new JTextFieldOperator(config, n);
+            testName.typeText("test_name");
+            break;
+        case 3:
+            JTextFieldOperator description = new JTextFieldOperator(config, n);
+            description.typeText("test_desc");
+            break;
+        case 4:
+            JTableOperator testTable = new JTableOperator(config);
+            testTable.clickOnCell(0, 0);
+            break;
+        case 5:
+            boolean isWindows = false;
+            if (System.getProperty("os.name").startsWith("Windows")) {
+                isWindows = true;
+            }
+            ComponentChooser fileText = new NameComponentChooser("file.txt");
+            JTextFieldOperator testConfig = new JTextFieldOperator(config, fileText);
+            testConfig.clearText();
+            Path p;
+            if (isWindows) {
+                p = Paths.get(System.getProperty("java.home").toString(), "bin", "java.exe");
+            } else {
+                p = Paths.get(System.getProperty("java.home").toString(), "bin", "java");
+            }
+            testConfig.typeText(p.toString());
+            break;
+        default:
+            return;
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Config_Edit2.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Config_Edit2.java
@@ -1,0 +1,76 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.runner.JUnitCore;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Test_Config_Edit2 extends Test {
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_Config_Edit2");
+    }
+
+    /**
+     * Verify that "Done" button in the Configuration Editor will finish all the
+     * questions. Run Configuration Editor by "Configure->Edit|Load|New
+     * Configuration" and check button.
+     *
+     * @throws ClassNotFoundException
+     *
+     * @throws InvocationTargetException
+     *
+     * @throws NoSuchMethodException
+     */
+
+    public void testImpl()
+            throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InterruptedException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.CONFIG_NAME, false);
+
+        ConfigDialog config = configuration.openByKey();
+
+        config.pushDoneConfigEditor();
+
+        if (config.getConfigDialog().isVisible()) {
+            errors.add("Config editor is not closed after clicking on Done button on configuration editor");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Config_Save1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Config_Save1.java
@@ -1,0 +1,90 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Test_Config_Save1 extends Test {
+    /**
+     * This test is to verify that \"File->Save\" menu item in Configuration Editor
+     * will save the current configuration back in a file if the file was loaded.
+     *
+     * @throws ClassNotFoundException
+     *
+     * @throws InvocationTargetException
+     *
+     * @throws NoSuchMethodException
+     *
+     * @throws InterruptedException
+     */
+    public void testImpl()
+            throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InterruptedException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        File createdWD = mainFrame.createWorkDirectoryInTemp();
+        addUsedFile(createdWD);
+
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.CONFIG_NAME, true);
+
+        ConfigDialog config = configuration.openByKey();
+        config.selectQuestion(2);
+        JTextFieldOperator jTextFieldOperator = new JTextFieldOperator(config.getConfigDialog(),
+                new NameComponentChooser("str.txt"));
+        String save = jTextFieldOperator.getText();
+        jTextFieldOperator.setText("some_description");
+        config.getFile_SaveMenu().push();
+        config.pushDoneConfigEditor();
+
+        mainFrame.closeCurrentTool();
+
+        mainFrame.getWorkDirectory().openWorkDirectory(createdWD);
+        Tools.waitForWDLoading(mainFrame.getJFrameOperator(), Tools.WDLoadingResult.SOME_NOTRUN);
+
+        config = configuration.openByKey();
+        config.selectQuestion(2);
+        jTextFieldOperator = new JTextFieldOperator(config.getConfigDialog(), new NameComponentChooser("str.txt"));
+        if (!jTextFieldOperator.getText().equals("some_description")) {
+            errors.add("description was not saved in configuration editor");
+        }
+        jTextFieldOperator.setText(save);
+        config.pushDoneConfigEditor();
+        mainFrame.closeCurrentTool();
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Report_Create1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Report_Create1.java
@@ -1,0 +1,115 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import static jthtest.ReportTools.findShowReportDialog;
+import static jthtest.ReportTools.openReportCreation;
+import static jthtest.ReportTools.pressCreate;
+import static jthtest.ReportTools.setPath;
+import static jthtest.ReportTools.startJavaTestWithDefaultWorkDirectory;
+import static jthtest.Tools.deleteDirectory;
+import static jthtest.Tools.deleteUserData;
+import static jthtest.Tools.findMainFrame;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.Test;
+
+public class Test_Report_Create1 extends Test {
+
+    /**
+     * This test case verifies that Create Report button under Report menu will
+     * create a report directory for a valid directory name for default values.
+     *
+     * @throws ClassNotFoundException
+     *
+     * @throws InvocationTargetException
+     *
+     * @throws NoSuchMethodException
+     *
+     */
+    public void testImpl()
+            throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InterruptedException {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+        String path = TEMP_PATH + REPORT_NAME + "_default" + File.separator;
+        deleteDirectory(path);
+        setPath(rep, path);
+
+        pressCreate(rep);
+        addUsedFile(path);
+
+        findShowReportDialog();
+
+        if (!new File(path + File.separator + "index.html").exists()) {
+            throw new JemmyException("index.html was not found");
+        }
+        if (!new File(path + File.separator + "reportdir.dat").exists()) {
+            throw new JemmyException("reportdir.dat was not found");
+        }
+        if (!new File(path + "html" + File.separator + "config.html").exists()) {
+            throw new JemmyException("config.html was not found");
+        }
+        if (!new File(path + "html" + File.separator + "env.html").exists()) {
+            throw new JemmyException("env.html was not found");
+        }
+        if (!new File(path + "html" + File.separator + "report.html").exists()) {
+            throw new JemmyException("report.html was not found");
+        }
+        if (!new File(path + "html" + File.separator + "error.html").exists()) {
+            throw new JemmyException("error.html was not found");
+        }
+        if (!new File(path + "html" + File.separator + "notRun.html").exists()) {
+            throw new JemmyException("notRun.html was not found");
+        }
+        if (!new File(path + "html" + File.separator + "failed.html").exists()) {
+            throw new JemmyException("failed.html was not found");
+        }
+        if (!new File(path + "html" + File.separator + "passed.html").exists()) {
+            throw new JemmyException("passed.html was not found");
+        }
+        if (!new File(path + "html" + File.separator + "report.css").exists()) {
+            throw new JemmyException("report.css was not found");
+        }
+        if (!new File(path + "text" + File.separator + "summary.txt").exists()) {
+            throw new JemmyException("summary.txt was not found");
+        }
+        if (!new File(path + "html" + File.separator + "excluded.html").exists()) {
+            throw new JemmyException("excluded.html was not found");
+        }
+    }
+}


### PR DESCRIPTION
Adding below automated JavaTest GUI Sanity Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1. Test_Config_Edit1.java
2. Test_Config_Edit2.java
3. Test_Config_Save1.java
4. Test_Report_Create1.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903153](https://bugs.openjdk.java.net/browse/CODETOOLS-7903153): Sanity Tests - Adding JavaTest GUI newly automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.java.net/jtharness pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/27.diff">https://git.openjdk.java.net/jtharness/pull/27.diff</a>

</details>
