### PR TITLE
7903170: Sanity Tests - Adding JavaTest GUI newly automated test scripts

### DIFF
--- a/gui-tests/src/gui/data/qsm_exclude.jtx
+++ b/gui-tests/src/gui/data/qsm_exclude.jtx
@@ -1,0 +1,32 @@
+#
+# $Id$
+#
+#
+# Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+# demo exclude list
+# demo exclude list
+
+# test name				bugid(s)   keyword(s)  brief description 
+lists/DoublyLinkedList/InsertTest.java#id0  0  	   test        test contains error

--- a/gui-tests/src/gui/data/qsm_exclude.jtx
+++ b/gui-tests/src/gui/data/qsm_exclude.jtx
@@ -2,7 +2,7 @@
 # $Id$
 #
 #
-# Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,7 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-# demo exclude list
-# demo exclude list
+# exclude test list for quick set mode
 
 # test name				bugid(s)   keyword(s)  brief description 
 lists/DoublyLinkedList/InsertTest.java#id0  0  	   test        test contains error

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_Exclude1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_Exclude1.java
@@ -1,0 +1,128 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JComboBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTabbedPaneOperator;
+import org.netbeans.jemmy.operators.JTableOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import javax.swing.JLabel;
+
+import jthtest.menu.Menu;
+
+public class Test_QSM_Exclude1 extends Config_New {
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_QSM_Exclude1");
+    }
+
+    /**
+     * Check exclude list adding in Quick set mode configuration editor
+     *
+     * @throws ClassNotFoundException
+     *
+     * @throws InvocationTargetException
+     *
+     * @throws NoSuchMethodException
+     *
+     */
+    @Test
+    public void test() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+            FileNotFoundException, InterruptedException, IOException {
+        JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+        Menu.getFile_Open_WorkDirectoryMenu(mainFrame).pushNoBlock();
+        JDialogOperator openDialog = new JDialogOperator(getToolResource("wdc.open.title"));
+        new JTextFieldOperator(openDialog, "").enterText("demowd_config");
+        jmbo.pushMenuNoBlock("Configure", "/");
+        Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+        JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+        JListOperator list = new JListOperator(configEditorDialog);
+        list.selectItem(1);
+        JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+        jmbo1.pushMenu("View", "/");
+        jmbo1.pushMenu("View/Quick Set Mode", "/");
+        JTabbedPaneOperator QSM_tabs = new JTabbedPaneOperator(configEditorDialog);
+
+        QSM_tabs.setSelectedIndex(1);
+        JRadioButtonOperator test = new JRadioButtonOperator(QSM_tabs, 3);
+        test.push();
+        JButtonOperator add = new JButtonOperator(QSM_tabs, "Add");
+        add.push();
+        JDialogOperator addDialog = new JDialogOperator("Select");
+        new JTextFieldOperator(addDialog, "").enterText("qsm_exclude.jtx");
+        jmbo1.pushMenuNoBlock("File", "/");
+        jmbo1.pushMenuNoBlock("File/Save", "/");
+        pushDoneConfigEditor(configEditorDialog);
+        JComboBoxOperator viewfilter = new JComboBoxOperator(mainFrame, 0);
+        viewfilter.selectItem(1);
+        JTabbedPaneOperator mainpane = new JTabbedPaneOperator(mainFrame, new NameComponentChooser("br.tabs"));
+        mainpane.setSelectedIndex(6);
+        JTableOperator filtered = new JTableOperator(mainpane);
+        String testname = ((JLabel) filtered.getRenderedComponent(0, 0)).getText();
+
+        assertEquals(
+                "Wrong test filtered when filtering via exclude list filter. Expected first test: lists/DoublyLinkedList/InsertTest.java#id0 But was: "
+                        + testname,
+                "lists/DoublyLinkedList/InsertTest.java#id0", testname);
+
+        jmbo.pushMenuNoBlock("Configure", "/");
+        Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+        configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+        list = new JListOperator(configEditorDialog);
+        list.selectItem(1);
+        jmbo1 = new JMenuBarOperator(configEditorDialog);
+        jmbo1.pushMenu("View", "/");
+        jmbo1.pushMenu("View/Quick Set Mode", "/");
+        QSM_tabs = new JTabbedPaneOperator(configEditorDialog);
+        QSM_tabs.setSelectedIndex(1);
+        JListOperator test1 = new JListOperator(QSM_tabs, 0);
+        test1.selectItem(0);
+        JButtonOperator remove = new JButtonOperator(QSM_tabs, "Remove");
+        remove.push();
+        JRadioButtonOperator test2 = new JRadioButtonOperator(QSM_tabs, 0);
+        test2.push();
+        jmbo1.pushMenuNoBlock("File", "/");
+        jmbo1.pushMenuNoBlock("File/Save", "/");
+        pushDoneConfigEditor(configEditorDialog);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_New1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_New1.java
@@ -1,0 +1,93 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+
+import javax.swing.JLabel;
+
+import jthtest.menu.Menu;
+
+public class Test_QSM_New1 extends Open_Test_Suite {
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_QSM_New1");
+    }
+
+    /**
+     * Verify that New button under File menu in the Quick Set mode configuration
+     * editor in an existing directory will reset Configuration Editor to empty.
+     *
+     * @throws ClassNotFoundException
+     *
+     * @throws InvocationTargetException
+     *
+     * @throws NoSuchMethodException
+     *
+     */
+    @Test
+    public void test()
+            throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InterruptedException {
+
+        JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+        Menu.getFile_Open_WorkDirectoryMenu(mainFrame).pushNoBlock();
+        JDialogOperator openDialog = new JDialogOperator(getToolResource("wdc.open.title"));
+        new JTextFieldOperator(openDialog, "").enterText("demowd_config");
+        waitForWDLoading(mainFrame, WDLoadingResult.SOME_NOTRUN);
+        jmbo.pushMenuNoBlock("Configure", "/");
+        Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+
+        JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+        JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+        jmbo1.pushMenu("View", "/");
+        jmbo1.pushMenu("View/Quick Set Mode", "/");
+        JDialogOperator qsm = new JDialogOperator(getExecResource("ce.name"));
+        JMenuBarOperator qsm_jmbo = new JMenuBarOperator(qsm);
+        qsm_jmbo.pushMenu("File", "/");
+        mainFrame.pressKey(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK);
+
+        JListOperator list = new JListOperator(configEditorDialog);
+        String lastlistitem = ((JLabel) list.getRenderedComponent(list.getModel().getSize() - 1)).getText();
+        String secondlastlistitem = ((JLabel) list.getRenderedComponent(list.getModel().getSize() - 2)).getText();
+
+        assertEquals("Last item was Expected: 'More...' But was: " + lastlistitem, " More...", lastlistitem);
+        assertEquals("Second Last item was Expected: 'Configuration Name' But was: " + secondlastlistitem,
+                "   Configuration Name", secondlastlistitem);
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_Save1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_Save1.java
@@ -96,7 +96,7 @@ public class Test_QSM_Save1 extends Config_New {
             qsm_index++;
         }
         jmbo1.pushMenu("File", "/");
-        jmbo1.pushMenuNoBlock("File/Save", "/");
+        jmbo1.pushMenu("File/Save", "/");
         pushDoneConfigEditor(configEditorDialog);
 
         jmbo.pushMenuNoBlock("Configure", "/");

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_Save1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_Save1.java
@@ -1,0 +1,328 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.awt.Rectangle;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JCheckBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTabbedPaneOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.operators.JTreeOperator;
+import org.netbeans.jemmy.operators.Operator;
+
+import javax.swing.JLabel;
+
+import jthtest.menu.Menu;
+
+public class Test_QSM_Save1 extends Config_New {
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_QSM_Save1");
+    }
+
+    /**
+     * Verify that Save button under File menu in Quick set mode configuration
+     * editor will save the current configuration back in a file if the file was
+     * loaded.
+     *
+     * @throws ClassNotFoundException
+     *
+     * @throws InvocationTargetException
+     *
+     * @throws NoSuchMethodException
+     */
+    @Test
+    public void test() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+            FileNotFoundException, InterruptedException, IOException {
+        int qsm_index = 0;
+        JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+        Menu.getFile_Open_WorkDirectoryMenu(mainFrame).pushNoBlock();
+        JDialogOperator openDialog = new JDialogOperator(getToolResource("wdc.open.title"));
+        new JTextFieldOperator(openDialog, "").enterText("demowd_config");
+
+        jmbo.pushMenuNoBlock("Configure", "/");
+        Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+        JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+        JListOperator list = new JListOperator(configEditorDialog);
+        list.selectItem(1);
+
+        JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+        jmbo1.pushMenu("View", "/");
+        jmbo1.pushMenu("View/Quick Set Mode", "/");
+        JTabbedPaneOperator QSM_tabs = new JTabbedPaneOperator(configEditorDialog);
+
+        while (qsm_index < 5) {
+            QSM_tabs.setSelectedIndex(qsm_index);
+            editQSMTab(configEditorDialog, QSM_tabs, qsm_index);
+            qsm_index++;
+        }
+        jmbo1.pushMenu("File", "/");
+        jmbo1.pushMenuNoBlock("File/Save", "/");
+        pushDoneConfigEditor(configEditorDialog);
+
+        jmbo.pushMenuNoBlock("Configure", "/");
+        Menu.getConfigure_LoadConfigurationMenu(mainFrame).pushNoBlock();
+        JDialogOperator loadConfigDialog = new JDialogOperator(getExecResource("wdc.loadconfig"));
+        JCheckBoxOperator launch_config_checkbox = new JCheckBoxOperator(loadConfigDialog);
+        launch_config_checkbox.clickMouse();
+        new JButtonOperator(loadConfigDialog, "Browse").push();
+        JDialogOperator loadConfigfinderDialog = new JDialogOperator(getExecResource("wdc.configchoosertitle"));
+        JTextFieldOperator browsetext = new JTextFieldOperator(loadConfigfinderDialog);
+        browsetext.clearText();
+        browsetext.enterText("democonfig.jti");
+
+        JButtonOperator loadbutton = new JButtonOperator(loadConfigDialog, getExecResource("wdc.load.btn"));
+        loadbutton.push();
+
+        configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+        list = new JListOperator(configEditorDialog);
+        list.selectItem(1);
+
+        jmbo1 = new JMenuBarOperator(configEditorDialog);
+        jmbo1.pushMenu("View", "/");
+        jmbo1.pushMenu("View/Quick Set Mode", "/");
+        QSM_tabs = new JTabbedPaneOperator(configEditorDialog);
+
+        while (qsm_index < 5) {
+            QSM_tabs.setSelectedIndex(qsm_index);
+            checkQSMTab(configEditorDialog, QSM_tabs, qsm_index);
+            resetQSMTab(configEditorDialog, QSM_tabs, qsm_index);
+            qsm_index++;
+        }
+
+        jmbo1 = new JMenuBarOperator(configEditorDialog);
+        jmbo1.pushMenu("File", "/");
+        jmbo1.pushMenuNoBlock("File/Save", "/");
+        pushDoneConfigEditor(configEditorDialog);
+
+    }
+
+    /**
+     * This function is to click on CheckBox on Quick Set Mode
+     *
+     * @param JTreeOperator
+     *
+     * @param row
+     */
+    public void clickOnCheckbox(JTreeOperator tree, int row) {
+        Rectangle r = tree.getRowBounds(row);
+        clickOnTreeRow(tree, row);
+        int x = Operator.getDefaultMouseButton();
+        tree.clickMouse((int) r.getX() + 6, (int) r.getY() + (int) (r.getHeight() / 2), 1, x, 0, false);
+    }
+
+    /**
+     * This function is to click on Tests Tree Row on Quick Set Mode
+     *
+     * @param JTreeOperator
+     *
+     * @param row
+     */
+    public void clickOnTreeRow(JTreeOperator tree, int row) {
+        tree.makeComponentVisible();
+        tree.scrollToRow(row);
+        tree.makeVisible(tree.getPathForRow(row));
+    }
+
+    /**
+     * This function is to edit configuration on Quick Set Mode. For example: Tests,
+     * ExcludeLists, Known Failures, prior status and Execution
+     *
+     * @param JDialogOperator
+     *
+     * @param JTabbedPaneOperator
+     *
+     * @param tab_num
+     *
+     * @throws FileNotFoundException
+     */
+    public void editQSMTab(JDialogOperator config, JTabbedPaneOperator tab, int tab_num) throws FileNotFoundException {
+        JRadioButtonOperator jrbo = null;
+        JButtonOperator add = null;
+        switch (tab_num) {
+        case 0:
+            jrbo = new JRadioButtonOperator(tab, 1);
+            jrbo.push();
+            JTreeOperator tree = new JTreeOperator(tab, 0);
+            clickOnCheckbox(tree, 1);
+            break;
+        case 1:
+            JRadioButtonOperator jrbo1 = new JRadioButtonOperator(tab, 3);
+            jrbo1.push();
+            add = new JButtonOperator(tab, "Add");
+            add.push();
+            JDialogOperator addDialog = new JDialogOperator("Select");
+            new JTextFieldOperator(addDialog, "").enterText("demo.jtx");
+            break;
+        case 2:
+            jrbo = new JRadioButtonOperator(tab, 1);
+            jrbo.push();
+            add = new JButtonOperator(tab, "Add");
+            add.push();
+            JDialogOperator addDialog1 = new JDialogOperator("Select");
+            new JTextFieldOperator(addDialog1, "").enterText("knownfailures.kfl");
+            break;
+        case 3:
+            JCheckBoxOperator jcbo = new JCheckBoxOperator(tab, 0);
+            jcbo.push();
+            JCheckBoxOperator passed = new JCheckBoxOperator(tab, 1);
+            passed.push();
+            break;
+        case 4:
+            new JTextFieldOperator(tab, 0).enterText("2");
+            new JTextFieldOperator(tab, 1).enterText("3");
+            break;
+        default:
+            fail("Trying to select non-existing tab on QSM");
+        }
+    }
+
+    /**
+     * This function is to check/verify configuration on Quick Set Mode. For
+     * example: Tests, ExcludeLists, Known Failures, prior status and Execution
+     *
+     * @param JDialogOperator
+     *
+     * @param JTabbedPaneOperator
+     *
+     * @param tab_num
+     */
+    public void checkQSMTab(JDialogOperator config, JTabbedPaneOperator tab, int tab_num) {
+        JListOperator jlo = null;
+        String actualpath = "";
+        String filepath = "";
+        Path path;
+        switch (tab_num) {
+        case 0:
+            return;
+        case 1:
+            jlo = new JListOperator(tab, 0);
+            filepath = ((JLabel) jlo.getRenderedComponent(0)).getText();
+            path = Paths.get("demo.jtx");
+            actualpath = path.toAbsolutePath().toString();
+            if (!filepath.equals(actualpath)) {
+                fail("Error in tab2 on QSM i.e. Exclude List");
+            }
+            break;
+        case 2:
+            jlo = new JListOperator(tab, 0);
+            filepath = ((JLabel) jlo.getRenderedComponent(0)).getText();
+            path = Paths.get("knownfailures.kfl");
+            actualpath = path.toAbsolutePath().toString();
+            if (!filepath.equals(actualpath)) {
+                fail("Error in tab3 on QSM i.e. Known Failures (KFL)");
+            }
+            break;
+        case 3:
+            JCheckBoxOperator passed = new JCheckBoxOperator(tab, 1);
+            JCheckBoxOperator other1 = new JCheckBoxOperator(tab, 2);
+            JCheckBoxOperator other2 = new JCheckBoxOperator(tab, 3);
+            JCheckBoxOperator other3 = new JCheckBoxOperator(tab, 4);
+            if (!passed.isSelected() || other1.isSelected() || other2.isSelected() || other3.isSelected()) {
+                fail("Error in tab4 on QSM i.e. Prior Status");
+            }
+            break;
+        case 4:
+            String jtfo = new JTextFieldOperator(tab, 0).getText();
+            String jtfo1 = new JTextFieldOperator(tab, 1).getText();
+            assertEquals("Error in tab5 on QSM i.e. Execution.", jtfo, "2");
+            assertEquals("Error in tab5 on QSM i.e. Execution", jtfo1, "3");
+            break;
+        default:
+            fail("Trying to select non-existing tab on QSM");
+        }
+    }
+
+    /**
+     * This function is to rest configuration on Quick Set Mode. For example: Tests,
+     * ExcludeLists, Known Failures, prior status and Execution
+     *
+     * @param JDialogOperator
+     *
+     * @param JTabbedPaneOperator
+     *
+     * @param tab_num
+     */
+    public void resetQSMTab(JDialogOperator config, JTabbedPaneOperator tab, int tab_num) {
+        JRadioButtonOperator jro = null;
+        JButtonOperator remove = null;
+        JListOperator jlo = null;
+        switch (tab_num) {
+        case 0:
+            JRadioButtonOperator jro1 = new JRadioButtonOperator(tab, 1);
+            jro1.push();
+            JTreeOperator tree = new JTreeOperator(tab, 0);
+            clickOnCheckbox(tree, 1);
+            jro = new JRadioButtonOperator(tab, 0);
+            jro.push();
+            break;
+        case 1:
+            jlo = new JListOperator(tab, 0);
+            jlo.selectItem(0);
+            remove = new JButtonOperator(tab, "Remove");
+            remove.push();
+            jro = new JRadioButtonOperator(tab, 0);
+            jro.push();
+            break;
+        case 2:
+            jlo = new JListOperator(tab, 0);
+            jlo.selectItem(0);
+            remove = new JButtonOperator(tab, "Remove");
+            remove.push();
+            jro = new JRadioButtonOperator(tab, 0);
+            jro.push();
+            break;
+        case 3:
+            JCheckBoxOperator passed = new JCheckBoxOperator(tab, 1);
+            passed.push();
+            JCheckBoxOperator jcbo = new JCheckBoxOperator(tab, 0);
+            jcbo.push();
+            break;
+        case 4:
+            new JTextFieldOperator(tab, 0).enterText("1");
+            new JTextFieldOperator(tab, 1).enterText("1");
+            break;
+        default:
+            fail("Trying to select non-existing tab on QSM");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_Test1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_QSM_Test1.java
@@ -1,0 +1,161 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Sanity_Tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.awt.Rectangle;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JComboBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTabbedPaneOperator;
+import org.netbeans.jemmy.operators.JTableOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.operators.JTreeOperator;
+import org.netbeans.jemmy.operators.Operator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import javax.swing.JLabel;
+
+import jthtest.menu.Menu;
+
+public class Test_QSM_Test1 extends Config_New {
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.Sanity_Tests.Test_QSM_Test1");
+    }
+
+    /**
+     * Check tests selection in Quick set mode configuration editor
+     *
+     * @throws ClassNotFoundException
+     *
+     * @throws InvocationTargetException
+     *
+     * @throws NoSuchMethodException
+     */
+
+    @Test
+    public void test() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+            FileNotFoundException, InterruptedException, IOException {
+
+        JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+        Menu.getFile_Open_WorkDirectoryMenu(mainFrame).pushNoBlock();
+        JDialogOperator openDialog = new JDialogOperator(getToolResource("wdc.open.title"));
+        new JTextFieldOperator(openDialog, "").enterText("demowd_config");
+        jmbo.pushMenuNoBlock("Configure", "/");
+        Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+
+        JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+        JListOperator list = new JListOperator(configEditorDialog);
+        list.selectItem(1);
+        JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+        jmbo1.pushMenu("View", "/");
+        jmbo1.pushMenu("View/Quick Set Mode", "/");
+        JTabbedPaneOperator QSM_tabs = new JTabbedPaneOperator(configEditorDialog);
+
+        QSM_tabs.setSelectedIndex(0);
+        JRadioButtonOperator test = new JRadioButtonOperator(QSM_tabs, 1);
+        test.push();
+        JTreeOperator tree = new JTreeOperator(QSM_tabs, 0);
+        clickOnCheckbox(tree, 1);
+        jmbo1.pushMenu("File");
+        jmbo1.pushMenu("File/Save", "/");
+        pushDoneConfigEditor(configEditorDialog);
+
+        JComboBoxOperator viewfilter = new JComboBoxOperator(mainFrame, 0);
+        viewfilter.selectItem(1);
+        JTabbedPaneOperator mainpane = new JTabbedPaneOperator(mainFrame, new NameComponentChooser("br.tabs"));
+        mainpane.setSelectedIndex(6);
+        JTableOperator filtered = new JTableOperator(mainpane);
+
+        String testname = ((JLabel) filtered.getRenderedComponent(0, 0)).getText();
+        assertEquals("Wrong tests selection in Quick set mode. Expected first test: BigNum/AddTest.java#id0 But was: "
+                + testname, "BigNum/AddTest.java#id0", testname);
+
+        jmbo.pushMenuNoBlock("Configure", "/");
+        Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+        configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+        list = new JListOperator(configEditorDialog);
+        list.selectItem(1);
+
+        jmbo1 = new JMenuBarOperator(configEditorDialog);
+        jmbo1.pushMenu("View", "/");
+        jmbo1.pushMenu("View/Quick Set Mode", "/");
+        QSM_tabs = new JTabbedPaneOperator(configEditorDialog);
+        QSM_tabs.setSelectedIndex(0);
+        JRadioButtonOperator jrb = new JRadioButtonOperator(QSM_tabs, 1);
+        jrb.push();
+        tree = new JTreeOperator(QSM_tabs, 0);
+        clickOnCheckbox(tree, 1);
+
+        JRadioButtonOperator jrb1 = new JRadioButtonOperator(QSM_tabs, 0);
+        jrb1.push();
+        jmbo1.pushMenuNoBlock("File");
+        jmbo1.pushMenuNoBlock("File/Save", "/");
+        pushDoneConfigEditor(configEditorDialog);
+    }
+
+    /**
+     * This function is used to click on the check boxes in JTreeOperator
+     *
+     * @param JTreeOperator
+     *
+     * @param row
+     */
+    public void clickOnCheckbox(JTreeOperator tree, int row) {
+        Rectangle r = tree.getRowBounds(row);
+        prepareToClickOnRow(tree, row);
+        int x = Operator.getDefaultMouseButton();
+        tree.clickMouse((int) r.getX() + 6, (int) r.getY() + (int) (r.getHeight() / 2), 1, x, 0, false);
+    }
+
+    /**
+     * This function is used to click on Test tree structure
+     *
+     * @param JTreeOperator
+     *
+     * @param row
+     */
+    public void prepareToClickOnRow(JTreeOperator tree, int row) {
+        tree.makeComponentVisible();
+        tree.scrollToRow(row);
+        tree.makeVisible(tree.getPathForRow(row));
+        if (!tree.isVisible(tree.getPathForRow(row))) {
+            fail("Failed, row is not visible after prepairing. Index " + row + ", tree width ");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Report_Create1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Report_Create1.java
@@ -120,15 +120,16 @@ public class Test_Report_Create1 extends Test {
         JButtonOperator jbo = new JButtonOperator(jdo, "No");
         jbo.push();
         JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
-        jmbo.pushMenuNoBlock("Report", "/");
+        jmbo.pushMenu("Report", "/");
         Menu.getReport_OpenReportMenu(mainFrame).pushNoBlock();
         Thread.sleep(2000);
         JDialogOperator reportDialog = new JDialogOperator(Tools.getExecResource("rh.open.title"));
         JTextFieldOperator openreporttext = new JTextFieldOperator(reportDialog, "");
-        openreporttext.enterText(path + File.separator + "index.html");
         Thread.sleep(2000);
+        openreporttext.enterText(path + File.separator + "index.html");
         JDialogOperator reportdialog = new JDialogOperator("Report Browser");
         JEditorPaneOperator jep = new JEditorPaneOperator(reportdialog);
+        Thread.sleep(2000);
         jep.clickMouse(jep.modelToView(jep.getPositionByText("HTML Report")).x,
                 jep.modelToView(jep.getPositionByText("HTML Report")).y, 1);
         JEditorPaneOperator jep1 = new JEditorPaneOperator(reportdialog);

--- a/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Report_Create1.java
+++ b/gui-tests/src/gui/src/jthtest/Sanity_Tests/Test_Report_Create1.java
@@ -35,21 +35,29 @@ import static jthtest.ReportTools.startJavaTestWithDefaultWorkDirectory;
 import static jthtest.Tools.deleteDirectory;
 import static jthtest.Tools.deleteUserData;
 import static jthtest.Tools.findMainFrame;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 
 import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JEditorPaneOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
 
 import jthtest.Test;
+import jthtest.Tools;
+import jthtest.menu.Menu;
 
 public class Test_Report_Create1 extends Test {
 
     /**
      * This test case verifies that Create Report button under Report menu will
-     * create a report directory for a valid directory name for default values.
+     * create a report directory for a valid directory name for default values and
+     * Verify that opening a valid report file will open the report.
      *
      * @throws ClassNotFoundException
      *
@@ -62,17 +70,13 @@ public class Test_Report_Create1 extends Test {
             throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InterruptedException {
         deleteUserData();
         startJavaTestWithDefaultWorkDirectory();
-
         JFrameOperator mainFrame = findMainFrame();
-
         JDialogOperator rep = openReportCreation(mainFrame);
         String path = TEMP_PATH + REPORT_NAME + "_default" + File.separator;
         deleteDirectory(path);
         setPath(rep, path);
-
         pressCreate(rep);
         addUsedFile(path);
-
         findShowReportDialog();
 
         if (!new File(path + File.separator + "index.html").exists()) {
@@ -111,5 +115,25 @@ public class Test_Report_Create1 extends Test {
         if (!new File(path + "html" + File.separator + "excluded.html").exists()) {
             throw new JemmyException("excluded.html was not found");
         }
+
+        JDialogOperator jdo = new JDialogOperator("View Report?");
+        JButtonOperator jbo = new JButtonOperator(jdo, "No");
+        jbo.push();
+        JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+        jmbo.pushMenuNoBlock("Report", "/");
+        Menu.getReport_OpenReportMenu(mainFrame).pushNoBlock();
+        Thread.sleep(2000);
+        JDialogOperator reportDialog = new JDialogOperator(Tools.getExecResource("rh.open.title"));
+        JTextFieldOperator openreporttext = new JTextFieldOperator(reportDialog, "");
+        openreporttext.enterText(path + File.separator + "index.html");
+        Thread.sleep(2000);
+        JDialogOperator reportdialog = new JDialogOperator("Report Browser");
+        JEditorPaneOperator jep = new JEditorPaneOperator(reportdialog);
+        jep.clickMouse(jep.modelToView(jep.getPositionByText("HTML Report")).x,
+                jep.modelToView(jep.getPositionByText("HTML Report")).y, 1);
+        JEditorPaneOperator jep1 = new JEditorPaneOperator(reportdialog);
+        Thread.sleep(2000);
+        assertTrue("Failure Beacuse Wrong page or unexpected error dialog box appeared after clicking on report link.",
+                jep1.getText().contains("JT Harness : Report"));
     }
 }


### PR DESCRIPTION
Adding below automated JavaTest GUI Sanity Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1. Test_QSM_Exclude1.java
2. Test_QSM_New1.java
3. Test_QSM_Save1.java
4. Test_QSM_Test1.java
5. Test_Report_Create1.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903170](https://bugs.openjdk.java.net/browse/CODETOOLS-7903170): Sanity Tests - Adding JavaTest GUI newly automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.java.net/jtharness pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/28.diff">https://git.openjdk.java.net/jtharness/pull/28.diff</a>

</details>
