### PR TITLE
7903178: Feature Tests - Adding JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Config_LoadEdit/Config_LoadEdit4.java
+++ b/gui-tests/src/gui/src/jthtest/Config_LoadEdit/Config_LoadEdit4.java
@@ -1,0 +1,66 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_LoadEdit;
+
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.ConfigTools;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_LoadEdit4 extends Test {
+
+    /**
+     * This test case verifies that Load button under file menu in configuration
+     * editor will display a warning with an option(Yes/No/Cancel) to save if the
+     * config has been opened and edited.
+     */
+
+    public void testImpl() throws Exception {
+        JTFrame mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.CONFIG_NAME, true);
+
+        ConfigDialog configDialog = configuration.openByKey();
+        new JTextFieldOperator(configDialog.getConfigDialog(), new NameComponentChooser("str.txt"))
+                .typeText("some_change");
+
+        configDialog.load(ConfigTools.SECOND_CONFIG_NAME, true);
+        JDialogOperator warning = new JDialogOperator(Tools.getExecResource("ce.load.warn.title"));
+        new JButtonOperator(warning, "No").push();
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_New/Config_New1.java
+++ b/gui-tests/src/gui/src/jthtest/Config_New/Config_New1.java
@@ -1,0 +1,59 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_New;
+
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.JTFrame;
+
+public class Config_New1 extends Test {
+
+    /**
+     * This test case verifies that New Configuration button under configure menu in
+     * an existing directory will reset it to an empty state.
+     */
+
+    public void testImpl() throws Exception {
+        JTFrame frame = JTFrame.startJTWithDefaultWorkDirectory();
+
+        ConfigDialog cd = frame.getConfiguration().openByKey();
+        boolean firstly = cd.isFullConfiguration();
+
+        cd.closeByMenu();
+
+        cd = frame.getConfiguration().create(true);
+
+        boolean secondly = cd.isFullConfiguration();
+
+        if (secondly) {
+            errors.add("Configuration is full after creation");
+        }
+        if (!firstly) {
+            errors.add("Warning: configuration was not full before creation");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_New/Config_New2.java
+++ b/gui-tests/src/gui/src/jthtest/Config_New/Config_New2.java
@@ -1,0 +1,50 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_New;
+
+import jthtest.Test;
+import jthtest.tools.JTFrame;
+
+public class Config_New2 extends Test {
+
+    /**
+     * This test case verifies that New Configuration button under configure menu
+     * will bring up an empty configuration editor.
+     */
+
+    public void testImpl() throws Exception {
+        JTFrame mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+        if (mainFrame.getConfiguration().create(false).isFullConfiguration()) {
+            errors.add("Newly created configuration is full while unexpected");
+        }
+
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_New/Config_New3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_New/Config_New3.java
@@ -1,0 +1,84 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_New;
+
+import java.io.File;
+
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JTableOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.JTFrame;
+
+public class Config_New3 extends Test {
+
+    /**
+     * This test case verifies that interview uses default values after first use of
+     * interview.
+     */
+
+    ConfigDialog cd;
+
+    public void testImpl() throws Exception {
+        JTFrame mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+        cd = mainFrame.getConfiguration().create(true);
+
+        fillConfiguration();
+
+        if (!cd.isFullConfiguration()) {
+            errors.add("");
+        }
+
+    }
+
+    private void fillConfiguration() {
+        JDialogOperator config = cd.getConfigDialog();
+        cd.pushLastConfigEditor();
+        new JTextFieldOperator(config, 1).typeText("some config");
+        cd.pushLastConfigEditor();
+        new JTextFieldOperator(config, 1).typeText("some description");
+        cd.pushLastConfigEditor();
+        JTableOperator table = new JTableOperator(config);
+        table.clickOnCell(0, 0);
+        cd.pushLastConfigEditor();
+        String text;
+        if (File.separatorChar == '/') {
+            text = System.getProperty("java.home") + "/bin/java";
+        } else {
+            text = System.getProperty("java.home") + "\\bin\\java.exe";
+        }
+        new JTextFieldOperator(config, new NameComponentChooser("file.txt")).typeText(text);
+        cd.pushLastConfigEditor();
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_New/Config_New4.java
+++ b/gui-tests/src/gui/src/jthtest/Config_New/Config_New4.java
@@ -1,0 +1,67 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_New;
+
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_New4 extends Test {
+
+    /**
+     * This test case verifies that making changes to a new configuration will
+     * display a warning to save changes if another new configuration is started
+     */
+
+    public Config_New4() {
+        depricated = true;
+    }
+
+    public void testImpl() throws Exception {
+        JTFrame mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.LOCAL_PATH, Tools.CONFIG_NAME, true);
+
+        ConfigDialog configDialog = configuration.openByKey();
+        configDialog.selectQuestion(2);
+        new JTextFieldOperator(configDialog.getConfigDialog(), new NameComponentChooser("str.txt"))
+                .typeText("some_text");
+        configDialog.closeByMenu();
+
+        new JDialogOperator("Warning: Unsaved Changes");
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1. Config_LoadEdit4
2. Config_New1
3. Config_New2
4. Config_New3
5. Config_New4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903178](https://bugs.openjdk.java.net/browse/CODETOOLS-7903178): Feature Tests - Adding JavaTest GUI legacy automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtharness pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.java.net/jtharness pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtharness/pull/30.diff">https://git.openjdk.java.net/jtharness/pull/30.diff</a>

</details>
