### PR TITLE
7903212: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Config_NewEdit/Config_NewEdit1.java
+++ b/gui-tests/src/gui/src/jthtest/Config_NewEdit/Config_NewEdit1.java
@@ -1,0 +1,59 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_NewEdit;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.JTFrame;
+
+public class Config_NewEdit1 extends Test {
+
+    /**
+     * This test case verifies that New Configuration button under file menu in
+     * configuration editor in an existing work directory will reset to empty.
+     */
+
+    public void testImpl() throws Exception {
+
+        mainFrame = new JTFrame(true);
+        mainFrame.openDefaultTestSuite();
+        mainFrame.getWorkDirectory().openWorkDirectory(Tools.LOCAL_PATH, Tools.DEFAULT_WD_NAME);
+        ConfigDialog config = mainFrame.getConfiguration().openByKey();
+
+        if (!config.isFullConfiguration()) {
+            errors.add(
+                    "Warning! Configuration in trunk directory isn't full for default WD. This can make tests unstable.");
+        }
+
+        config.getFile_NewConfigurationMenu().push();
+
+        if (config.isFullConfiguration()) {
+            errors.add("Configuration was not reset after creation");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_NewEdit/Config_NewEdit2.java
+++ b/gui-tests/src/gui/src/jthtest/Config_NewEdit/Config_NewEdit2.java
@@ -1,0 +1,73 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_NewEdit;
+
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_NewEdit2 extends Test {
+
+    /**
+     * This test case verifies that New Configuration button under file menu in
+     * configuration editor in a new work directory will save interview in a new
+     * file.
+     */
+
+    public void testImpl() throws Exception {
+
+        mainFrame = new JTFrame(true);
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.CONFIG_NAME, true);
+        ConfigDialog config = configuration.openByKey();
+
+        if (!config.isFullConfiguration()) {
+            errors.add(
+                    "Warning! Configuration in trunk directory isn't full for default WD. This can make tests unstable.");
+        }
+        config.getFile_NewConfigurationMenu().push();
+
+        if (config.isFullConfiguration()) {
+            errors.add("Configuration was not reset after creation");
+        }
+
+        config.pushDoneConfigEditor();
+
+        new JDialogOperator(ConfigDialog.getConfirmCloseIncomleteConfigurationDialogName());
+        new JButtonOperator(new JDialogOperator(ConfigDialog.getConfirmCloseIncomleteConfigurationDialogName())).push();
+        new JDialogOperator(ConfigDialog.getSaveConfigurationDialogName());
+
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_NewEdit/Config_NewEdit3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_NewEdit/Config_NewEdit3.java
@@ -1,0 +1,66 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_NewEdit;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public class Config_NewEdit3 extends Test {
+
+    /**
+     * This test case verifies that New Configuration button under file menu in
+     * configuration editor will display a warning with an option (Yes/No/Cancel) to
+     * save if the config has been opened and edited.
+     */
+
+    public void testImpl() throws Exception {
+        JTFrame mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.CONFIG_NAME, true);
+
+        ConfigDialog config = configuration.openByKey();
+        if (!config.isFullConfiguration()) {
+            errors.add(
+                    "Warning! Configuration in trunk directory isn't full for default WD. This can make tests unstable.");
+        }
+
+        config.getFile_NewConfigurationMenu().push();
+        if (config.isFullConfiguration()) {
+            errors.add("Configuration was not reset after creation");
+        }
+        config.pushDoneConfigEditor();
+        new JDialogOperator(ConfigDialog.getConfirmCloseIncomleteConfigurationDialogName());
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_SaveEdit/Config_SaveEdit1.java
+++ b/gui-tests/src/gui/src/jthtest/Config_SaveEdit/Config_SaveEdit1.java
@@ -1,0 +1,84 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_SaveEdit;
+
+import java.io.File;
+
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_SaveEdit1 extends Test {
+
+    /**
+     * This test case verifies that saving an interview file from file menu in
+     * configuration editor will save the configuration file in a loaded file.
+     */
+
+    public void testImpl() throws Exception {
+
+        mainFrame = new JTFrame(true);
+        mainFrame.openDefaultTestSuite();
+        File createdWD = mainFrame.createWorkDirectoryInTemp();
+        addUsedFile(createdWD);
+
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(Tools.CONFIG_NAME, true);
+
+        ConfigDialog config = configuration.openByKey();
+        config.selectQuestion(2);
+        JTextFieldOperator jTextFieldOperator = new JTextFieldOperator(config.getConfigDialog(),
+                new NameComponentChooser("str.txt"));
+        String save = jTextFieldOperator.getText();
+        jTextFieldOperator.setText("some_description");
+
+        config.getFile_SaveMenu().push();
+        config.pushDoneConfigEditor();
+
+        mainFrame.closeCurrentTool();
+        mainFrame.getWorkDirectory().openWorkDirectory(createdWD);
+        Tools.waitForWDLoading(mainFrame.getJFrameOperator(), Tools.WDLoadingResult.SOME_NOTRUN);
+
+        config = configuration.openByKey();
+        config.selectQuestion(2);
+
+        jTextFieldOperator = new JTextFieldOperator(config.getConfigDialog(), new NameComponentChooser("str.txt"));
+        if (!jTextFieldOperator.getText().equals("some_description")) {
+            errors.add("description was not saved");
+        }
+
+        jTextFieldOperator.setText(save);
+        config.pushDoneConfigEditor();
+        mainFrame.closeCurrentTool();
+        mainFrame.closeAllTools();
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_SaveEdit/Config_SaveEdit2.java
+++ b/gui-tests/src/gui/src/jthtest/Config_SaveEdit/Config_SaveEdit2.java
@@ -1,0 +1,81 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_SaveEdit;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.ConfigTools;
+
+public class Config_SaveEdit2 extends ConfigTools {
+
+    /**
+     * This test case verifies that saving an interview file from file menu in
+     * configuration editor will save the configuration file in a new file if there
+     * is no loaded jti file.
+     */
+
+    public static void main(String args[]) {
+        JUnitCore.main("jthtest.gui.Config_SaveEdit.Config_SaveEdit2");
+    }
+
+    @Test
+    public void testConfig_SaveEdit2()
+            throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InterruptedException {
+        File f = new File(LOCAL_PATH + "jt_gui_test_Config_SaveEdit2_test_this_file_will_be_deleted.jti");
+        if (f.exists())
+            f.delete();
+        f = null;
+        startJavatestNewDesktop();
+        JFrameOperator mainFrame = findMainFrame();
+        closeQS(mainFrame);
+
+        openTestSuite(mainFrame);
+        createWorkDirInTemp(mainFrame);
+        openConfigCreation(mainFrame);
+        JDialogOperator config = findConfigEditor(mainFrame);
+
+        saveConfig(config, "jt_gui_test_Config_SaveEdit2_test_this_file_will_be_deleted");
+
+        f = new File(LOCAL_PATH + "jt_gui_test_Config_SaveEdit2_test_this_file_will_be_deleted.jti");
+        int t = 0;
+        while (t < 1000 && !f.exists()) {
+            f = new File(LOCAL_PATH + "jt_gui_test_Config_SaveEdit2_test_this_file_will_be_deleted.jti");
+            t += 100;
+            Thread.sleep(100);
+        }
+        if (!f.exists())
+            throw new JemmyException("File was not created");
+        f.delete();
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.Config_NewEdit1.java
2.Config_NewEdit2.java
3.Config_NewEdit3.java
4.Config_SaveEdit1.java
5.Config_SaveEdit2.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903212](https://bugs.openjdk.org/browse/CODETOOLS-7903212): Feature Tests - Adding five JavaTest GUI legacy automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/jtharness pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/31.diff">https://git.openjdk.org/jtharness/pull/31.diff</a>

</details>
