### PR TITLE
7903224: InitialUrlFilter::isInitialUrlMatch should do early detection of incorrect initial URL passed

### DIFF
--- a/src/com/sun/javatest/InitialUrlFilter.java
+++ b/src/com/sun/javatest/InitialUrlFilter.java
@@ -29,6 +29,7 @@ package com.sun.javatest;
 import com.sun.javatest.util.I18NResourceBundle;
 
 import java.io.File;
+import java.util.Objects;
 
 /**
  * Filters tests based on a set of initial files or URLs.
@@ -119,6 +120,10 @@ public class InitialUrlFilter extends TestFilter {
      * URL.
      */
     public static boolean isInitialUrlMatch(String toCheck, String compareTo) {
+        Objects.requireNonNull(compareTo, "Known initial URL to compare should not be `null`");
+        if (compareTo.isEmpty()) {
+            throw new IllegalArgumentException("Known initial URL to compare should not be empty");
+        }
         if (toCheck.equals(compareTo))  // direct match of test
         {
             return true;


### PR DESCRIPTION
Method of InitialUrlFilter class

    public static boolean isInitialUrlMatch(String toCheck, String compareTo) {

contains

```
   compareTo.charAt(compareTo.length() - 1)
```


This would lead to StringIndexOutOfBounds in case if `compareTo` is empty.

It would be better to check correctness of passed `compareTo` arg earlier

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903224](https://bugs.openjdk.org/browse/CODETOOLS-7903224): InitialUrlFilter::isInitialUrlMatch should do early detection of incorrect initial URL passed


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.org/jtharness pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/32.diff">https://git.openjdk.org/jtharness/pull/32.diff</a>

</details>
