### PR TITLE
7903229: ParameterFilter - check initFiles for any File with an empty path

### DIFF
--- a/src/com/sun/javatest/ParameterFilter.java
+++ b/src/com/sun/javatest/ParameterFilter.java
@@ -234,6 +234,14 @@ public class ParameterFilter extends ObservableTestFilter {
 
             String[] initStrings = p.getTests();
             File[] initFiles = stringsToFiles(initStrings);
+            if (initFiles != null) {
+                for (File file : initFiles) {
+                    if (file.getPath().isEmpty()) {
+                        throw new IllegalArgumentException("The passed configuration parameters contain an empty path " +
+                                "identifying a test or a folder of tests within the test suite to be run");
+                    }
+                }
+            }
 
             // could optimize out this code if rmInitFiles is false
             iurlFilter = new InitialUrlFilter(initFiles);


### PR DESCRIPTION
ParameterFilter.java : method `update` could check check initFiles (which is result of `stringsToFiles()` call) for any File with an empty path

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903229](https://bugs.openjdk.org/browse/CODETOOLS-7903229): ParameterFilter - check initFiles for any File with an empty path (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/jtharness.git pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/33.diff">https://git.openjdk.org/jtharness/pull/33.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/33#issuecomment-1172923750)