### PR TITLE
Fix jtreg build with /usr/bin/git available

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -272,8 +272,8 @@ harness-variety=Full Bundle
         </tstamp>
         <available file="git" type="file" filepath="${env.PATH}" property="GIT_FOUND"/>
         <exec if:set="GIT_FOUND" executable="git"
-              failonerror="true"
-              failifexecutionfails="true"
+              failonerror="false"
+              failifexecutionfails="false"
               outputproperty="BUILT_FROM_COMMIT">
             <arg line="--git-dir=${basedir}/.git log -1 --format=%h"/>
         </exec>


### PR DESCRIPTION
I have tried to rebase JTREG on top of `jt6.0-b23` or `master` of jtharness but with `/usr/bin/git` available JTREG then does not build:
```
generate.release.file:
BUILD FAILED
.../jtreg/build/deps/jtharness/src/jtharness-jt6.0-b23/build/build.xml:277: exec returned: 128
```
This reverts a part of commit [8a0bc39980118fc47d9fbe161f1bc1fa75aa854b](https://github.com/openjdk/jtharness/commit/8a0bc39980118fc47d9fbe161f1bc1fa75aa854b) by @dbessono where this change is not described and it may have been unintentional.
Unforunately I am not yet Author so I do not yet have a JBS account so I cannot file it to JBS (Java Bug System).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/jtharness pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/34.diff">https://git.openjdk.org/jtharness/pull/34.diff</a>

</details>
