### PR TITLE
Fix NullPointerException on a parallel run

### DIFF
--- a/src/com/sun/javatest/TRT_TreeNode.java
+++ b/src/com/sun/javatest/TRT_TreeNode.java
@@ -803,8 +803,10 @@ public class TRT_TreeNode implements TestResultTable.TreeNode {
                 if (Objects.equals(filesToScan[i], this.name)) {
                     processFile(thisDir);
                 } else {
-                    processFile(new File(TestResultTable.getRootRelativePath(this) +
-                            File.separator + filesToScan[i]));
+                    String path = TestResultTable.getRootRelativePath(this);
+                    processFile("".equals(path) // Zero length string if the node is a root
+                        ? new File(filesToScan[i])
+                        : new File(path + File.separator + filesToScan[i]));
                 }
             }   // for
         } else {


### PR DESCRIPTION
```
Error: Unexpected exception occurred! java.lang.NullPointerException
java.lang.NullPointerException
	at com.sun.javatest.regtest.config.TestProperties$Cache.getEntryInternal(TestProperties.java:515)
	at com.sun.javatest.regtest.config.TestProperties$Cache.getEntryInternal(TestProperties.java:515)
	at com.sun.javatest.regtest.config.TestProperties$Cache.getEntry(TestProperties.java:502)
	at com.sun.javatest.regtest.config.TestProperties.getEntry(TestProperties.java:170)
	at com.sun.javatest.regtest.config.TestProperties.getTestNGRoot(TestProperties.java:123)
	at com.sun.javatest.regtest.config.RegressionTestFinder.scanFile(RegressionTestFinder.java:143)
	at com.sun.javatest.finder.TagTestFinder.scan(TagTestFinder.java:115)
	at com.sun.javatest.TestFinder.read(TestFinder.java:433)
	at com.sun.javatest.TRT_TreeNode.processFile(TRT_TreeNode.java:1259)
	at com.sun.javatest.TRT_TreeNode.scanIfNeeded(TRT_TreeNode.java:807)
	at com.sun.javatest.TRT_TreeNode.getTreeNode(TRT_TreeNode.java:616)
	at com.sun.javatest.TestResultTable.findNode(TestResultTable.java:400)
	at com.sun.javatest.TestResultTable.lookupNode(TestResultTable.java:533)
	at com.sun.javatest.TestResultTable.lookupInitURL(TestResultTable.java:571)
	at com.sun.javatest.TestResultTable.validatePath(TestResultTable.java:1000)
	at com.sun.javatest.regtest.config.TestManager.validatePath(TestManager.java:299)
	at com.sun.javatest.regtest.config.TestManager.getTests(TestManager.java:271)
	at com.sun.javatest.regtest.tool.Tool.createParameters(Tool.java:1659)
	at com.sun.javatest.regtest.tool.Tool.run(Tool.java:1293)
	at com.sun.javatest.regtest.tool.Tool.run(Tool.java:1082)
	at com.sun.javatest.regtest.tool.Tool.main(Tool.java:155)
	at com.sun.javatest.regtest.Main.main(Main.java:46)
```

Some debug output showing the problem:
```
	scanIfNeeded getRootRelativePath= separator=/ filesToScan[i]=resultdir
	processFile file=/resultdir isAbsolute=true
	TestFinder.java read file=/resultdir isAbsolute=true
	scanFile caller file=/resultdir
	scanFile File=/resultdir
	TestProperties.java:dir=/ rootDir=/home/azul/azul/zulu11-git/test/hotspot/jtreg file2=/resultdir file2.getParentFile()=/
	TestProperties.java:dir=null rootDir=/home/azul/azul/zulu11-git/test/hotspot/jtreg file2=/resultdir file2.getParentFile()=/
```
This happens with jtreg using `-w:resultdir` . `getRootRelativePath()` returns empty `""` path. Other option would be to return `"."` but in such case it broke some other code.

This problem does not happen during a single run. It happens only when jtreg is being run in parallel, in my case:
```
	seq 1 100000|xargs -n1 -P64 ./runtest
	#! /bin/bash
	dir=result-test$$
	rm -rf $dir
	mkdir $dir
	set -o pipefail
	(JAVA_HOME=$HOME/azul/zulu11-git/build/linux-x86_64-normal-server-release/images/jdk/; $JAVA_HOME/bin/java -classpath $HOME/azul/jtreg/build/images/jtreg/lib/jtreg.jar:$HOME/azul/jtreg/build/images/jtreg/lib/javatest.jar:$HOME/azul/jtreg/build/images/jtreg/lib/asmtools.jar com.sun.javatest.regtest.Main -testjdk:$JAVA_HOME -othervm -verbose -ignore:quiet -retain:all -a -conc:1 -timeout:10 -vmoptions:-XX:+UnlockExperimentalVMOptions -w:$dir -noreport -dir:$JAVA_HOME/../../../../test/jdk/ -nativepath:$JAVA_HOME/../test/hotspot/jtreg/native ../hotspot/jtreg/vmTestbase/nsk/jdi/stress/serial/heapwalking001/TestDescription.java |& tee $dir/err) || exit 255
	rm -rf $dir
```

Unforunately I am not yet Author so I do not yet have a JBS account so I cannot file it to JBS (Java Bug System).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/jtharness pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/35.diff">https://git.openjdk.org/jtharness/pull/35.diff</a>

</details>
