### PR TITLE
7903263: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/New/New3.java
+++ b/gui-tests/src/gui/src/jthtest/New/New3.java
@@ -1,0 +1,75 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.New;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import junit.framework.Assert;
+
+public class New3 extends New {
+
+    /**
+     * This test case verifies that choosing to create a new configuration will no
+     * not start a new configuration if the start configuration editor checkbox is
+     * unchecked.
+     */
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.New.New3");
+    }
+
+    @Test
+    public void testNew3() throws InterruptedException {
+        startTestRun(quickStartDialog);
+
+        next(quickStartDialog);
+
+        pickDefaultTestsuite(quickStartDialog);
+
+        next(quickStartDialog);
+
+        createConfiguration(quickStartDialog);
+
+        next(quickStartDialog);
+
+        pickTempWorkDir(quickStartDialog);
+
+        next(quickStartDialog);
+
+        finish(quickStartDialog, false, false);
+
+        mainFrame = new JFrameOperator(WINDOWNAME);
+
+        Assert.assertTrue(
+                "choosing to create a new configuration will not start a new configuration if the start configuration editor checkbox is unchecked.",
+                mainFrame.getOwnedWindows().length != 3);
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/New/New5.java
+++ b/gui-tests/src/gui/src/jthtest/New/New5.java
@@ -1,0 +1,59 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.New;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+public class New5 extends New {
+
+    /**
+     * This test case verifies that using an existing configuration template file
+     * will let user continue, the Next button is enabled.
+     */
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.New.New5");
+    }
+
+    @Test
+    public void testNew5() {
+        startTestRun(quickStartDialog);
+
+        next(quickStartDialog);
+
+        pickDefaultTestsuite(quickStartDialog);
+
+        next(quickStartDialog);
+
+        useConfigTemplate(quickStartDialog);
+
+        next(quickStartDialog);
+
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/New/New6.java
+++ b/gui-tests/src/gui/src/jthtest/New/New6.java
@@ -1,0 +1,62 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.New;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+public class New6 extends New {
+
+    /**
+     * This test case verifies that using a non-existing configuration template file
+     * will not let the user continue, the Next button is disabled.
+     */
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.New.New6");
+    }
+
+    @Test
+    public void testNew6() {
+        startTestRun(quickStartDialog);
+
+        next(quickStartDialog);
+
+        pickDefaultTestsuite(quickStartDialog);
+
+        next(quickStartDialog);
+
+        useMissingConfigTemplate(quickStartDialog);
+
+        if (isNextEnabled(quickStartDialog))
+            fail("Button 'Next' must be disabled");
+
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/New/New7.java
+++ b/gui-tests/src/gui/src/jthtest/New/New7.java
@@ -1,0 +1,55 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.New;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+public class New7 extends New {
+
+    /**
+     * This test case verifies that using a valid test suite will let the user
+     * continue, the Next button is enabled.
+     */
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.New.New7");
+    }
+
+    @Test
+    public void testNew7() {
+        startTestRun(quickStartDialog);
+
+        next(quickStartDialog);
+
+        pickDefaultTestsuite(quickStartDialog);
+
+        next(quickStartDialog);
+
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/New/New8.java
+++ b/gui-tests/src/gui/src/jthtest/New/New8.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.New;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+public class New8 extends New {
+
+    /**
+     * This test case verifies that creating a valid path for workdirectory will let
+     * user continue, Next button is enabled.
+     */
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.New.New8");
+    }
+
+    @Test
+    public void testNew8() {
+        startTestRun(quickStartDialog);
+
+        next(quickStartDialog);
+
+        pickDefaultTestsuite(quickStartDialog);
+
+        next(quickStartDialog);
+
+        createConfiguration(quickStartDialog);
+
+        next(quickStartDialog);
+
+        pickTempWorkDir(quickStartDialog);
+
+        next(quickStartDialog);
+
+    }
+
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.New3.java
2.New5.java
3.New6.java
4.New7.java
5.New8.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903263](https://bugs.openjdk.org/browse/CODETOOLS-7903263): Feature Tests - Adding five JavaTest GUI legacy automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jtharness pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/36.diff">https://git.openjdk.org/jtharness/pull/36.diff</a>

</details>
