### PR TITLE
7903268: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir03.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir03.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.CreateWorkdir;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir03 extends Test {
+
+	/**
+	 * This test case verifies that creating an existing workdirectory will generate
+	 * an error message.
+	 */
+
+	public void testImpl() throws Exception {
+		startJavaTestWithDefaultTestSuite();
+		JFrameOperator mainFrame = findMainFrame();
+
+		String path = DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME;
+		deleteDirectory(path);
+		createWorkDirectory(path, true, mainFrame);
+		createWorkDirectory(path, false, mainFrame);
+		addUsedFile(path);
+
+		try {
+			new JDialogOperator(getToolResource("wdc.exists_openIt.title"));
+		} catch (JemmyException e) {
+			errors.add(
+					"Error message offering user to open existing work directory insted of creation it was not found");
+		}
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir03.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir03.java
@@ -38,26 +38,26 @@ import static jthtest.workdir.Workdir.*;
 
 public class CreateWorkdir03 extends Test {
 
-	/**
-	 * This test case verifies that creating an existing workdirectory will generate
-	 * an error message.
-	 */
+    /**
+     * This test case verifies that creating an existing workdirectory will generate
+     * an error message.
+     */
 
-	public void testImpl() throws Exception {
-		startJavaTestWithDefaultTestSuite();
-		JFrameOperator mainFrame = findMainFrame();
+    public void testImpl() throws Exception {
+        startJavaTestWithDefaultTestSuite();
+        JFrameOperator mainFrame = findMainFrame();
 
-		String path = DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME;
-		deleteDirectory(path);
-		createWorkDirectory(path, true, mainFrame);
-		createWorkDirectory(path, false, mainFrame);
-		addUsedFile(path);
+        String path = DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME;
+        deleteDirectory(path);
+        createWorkDirectory(path, true, mainFrame);
+        createWorkDirectory(path, false, mainFrame);
+        addUsedFile(path);
 
-		try {
-			new JDialogOperator(getToolResource("wdc.exists_openIt.title"));
-		} catch (JemmyException e) {
-			errors.add(
-					"Error message offering user to open existing work directory insted of creation it was not found");
-		}
-	}
+        try {
+            new JDialogOperator(getToolResource("wdc.exists_openIt.title"));
+        } catch (JemmyException e) {
+            errors.add(
+                    "Error message offering user to open existing work directory insted of creation it was not found");
+        }
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir14.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir14.java
@@ -39,19 +39,19 @@ import static jthtest.workdir.Workdir.*;
 
 public class CreateWorkdir14 extends Test {
 
-	/**
-	 * This test case verifies that Cancel button in the Create Work Directory will
-	 * remove the dialog box.
-	 */
+    /**
+     * This test case verifies that Cancel button in the Create Work Directory will
+     * remove the dialog box.
+     */
 
-	public void testImpl() throws Exception {
-		startJavaTestWithDefaultTestSuite();
+    public void testImpl() throws Exception {
+        startJavaTestWithDefaultTestSuite();
 
-		JFrameOperator mainFrame = findMainFrame();
-		JDialogOperator wdCreate = openOpenWorkDirectoryDialog(mainFrame);
-		new JButtonOperator(wdCreate, "Cancel").push();
+        JFrameOperator mainFrame = findMainFrame();
+        JDialogOperator wdCreate = openOpenWorkDirectoryDialog(mainFrame);
+        new JButtonOperator(wdCreate, "Cancel").push();
 
-		if (wdCreate.isVisible())
-			throw new JemmyException("Dialog box is visible after pressing Cancel button");
-	}
+        if (wdCreate.isVisible())
+            throw new JemmyException("Dialog box is visible after pressing Cancel button");
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir14.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir14.java
@@ -1,0 +1,57 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.CreateWorkdir;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir14 extends Test {
+
+	/**
+	 * This test case verifies that Cancel button in the Create Work Directory will
+	 * remove the dialog box.
+	 */
+
+	public void testImpl() throws Exception {
+		startJavaTestWithDefaultTestSuite();
+
+		JFrameOperator mainFrame = findMainFrame();
+		JDialogOperator wdCreate = openOpenWorkDirectoryDialog(mainFrame);
+		new JButtonOperator(wdCreate, "Cancel").push();
+
+		if (wdCreate.isVisible())
+			throw new JemmyException("Dialog box is visible after pressing Cancel button");
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir21.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir21.java
@@ -38,22 +38,22 @@ import jthtest.tools.JTFrame;
 
 public class CreateWorkdir21 extends Test {
 
-	/**
-	 * This test case verifies that creating a work directory with spaces in the
-	 * filename should work properly.
-	 */
+    /**
+     * This test case verifies that creating a work directory with spaces in the
+     * filename should work properly.
+     */
 
-	public void testImpl() throws Exception {
-		JTFrame mainFrame = JTFrame.startJTWithDefaultTestSuite();
+    public void testImpl() throws Exception {
+        JTFrame mainFrame = JTFrame.startJTWithDefaultTestSuite();
 
-		File wd = mainFrame.getWorkDirectory().createWorkDirectory(Tools.TEMP_PATH, "path with spaces", true);
-		addUsedFile(wd);
+        File wd = mainFrame.getWorkDirectory().createWorkDirectory(Tools.TEMP_PATH, "path with spaces", true);
+        addUsedFile(wd);
 
-		if (!wd.exists()) {
-			errors.add(("Workdir with spaces ('path with spaces') was not created in temp directory. Tried to create "
-					+ wd.getAbsolutePath()));
-		}
+        if (!wd.exists()) {
+            errors.add(("Workdir with spaces ('path with spaces') was not created in temp directory. Tried to create "
+                    + wd.getAbsolutePath()));
+        }
 
-	}
+    }
 
 }

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir21.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir21.java
@@ -1,0 +1,59 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.CreateWorkdir;
+
+import java.io.File;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.Test;
+
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+
+public class CreateWorkdir21 extends Test {
+
+	/**
+	 * This test case verifies that creating a work directory with spaces in the
+	 * filename should work properly.
+	 */
+
+	public void testImpl() throws Exception {
+		JTFrame mainFrame = JTFrame.startJTWithDefaultTestSuite();
+
+		File wd = mainFrame.getWorkDirectory().createWorkDirectory(Tools.TEMP_PATH, "path with spaces", true);
+		addUsedFile(wd);
+
+		if (!wd.exists()) {
+			errors.add(("Workdir with spaces ('path with spaces') was not created in temp directory. Tried to create "
+					+ wd.getAbsolutePath()));
+		}
+
+	}
+
+}

--- a/gui-tests/src/gui/src/jthtest/OpenTestSuite/OpenTestSuite1.java
+++ b/gui-tests/src/gui/src/jthtest/OpenTestSuite/OpenTestSuite1.java
@@ -35,21 +35,21 @@ import org.netbeans.jemmy.operators.JTabbedPaneOperator;
 
 public class OpenTestSuite1 extends OpenTestSuite {
 
-	/**
-	 * This test case verifies that opening an existing test suite would correctly
-	 * load tests.
-	 */
+    /**
+     * This test case verifies that opening an existing test suite would correctly
+     * load tests.
+     */
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.OpenTestSuite.OpenTestSuite1");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.OpenTestSuite.OpenTestSuite1");
+    }
 
-	@Test
-	public void testOpenTestSuite1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+    @Test
+    public void testOpenTestSuite1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-		openTestSuite(mainFrame);
-		waitForWDLoading(mainFrame, WDLoadingResult.SOME_NOTRUN);
-		new JTabbedPaneOperator(mainFrame, TAB_CAPTION);
-	}
+        openTestSuite(mainFrame);
+        waitForWDLoading(mainFrame, WDLoadingResult.SOME_NOTRUN);
+        new JTabbedPaneOperator(mainFrame, TAB_CAPTION);
+    }
 
 }

--- a/gui-tests/src/gui/src/jthtest/OpenTestSuite/OpenTestSuite1.java
+++ b/gui-tests/src/gui/src/jthtest/OpenTestSuite/OpenTestSuite1.java
@@ -1,0 +1,55 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.OpenTestSuite;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JTabbedPaneOperator;
+
+public class OpenTestSuite1 extends OpenTestSuite {
+
+	/**
+	 * This test case verifies that opening an existing test suite would correctly
+	 * load tests.
+	 */
+
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.OpenTestSuite.OpenTestSuite1");
+	}
+
+	@Test
+	public void testOpenTestSuite1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+		openTestSuite(mainFrame);
+		waitForWDLoading(mainFrame, WDLoadingResult.SOME_NOTRUN);
+		new JTabbedPaneOperator(mainFrame, TAB_CAPTION);
+	}
+
+}

--- a/gui-tests/src/gui/src/jthtest/OpenTestSuite/OpenTestSuite2.java
+++ b/gui-tests/src/gui/src/jthtest/OpenTestSuite/OpenTestSuite2.java
@@ -37,29 +37,29 @@ import org.netbeans.jemmy.operators.JTabbedPaneOperator;
 
 public class OpenTestSuite2 extends OpenTestSuite {
 
-	/**
-	 * This test case verifies that opening an existing test suite twice would not
-	 * cause an error.
-	 */
+    /**
+     * This test case verifies that opening an existing test suite twice would not
+     * cause an error.
+     */
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.OpenTestSuite.OpenTestSuite2");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.OpenTestSuite.OpenTestSuite2");
+    }
 
-	@Test
-	public void testOpenTestSuite2() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
-		openTestSuite(mainFrame);
-		openTestSuite(mainFrame);
-		waitForWDLoading(mainFrame, WDLoadingResult.SOME_NOTRUN);
+    @Test
+    public void testOpenTestSuite2() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        openTestSuite(mainFrame);
+        openTestSuite(mainFrame);
+        waitForWDLoading(mainFrame, WDLoadingResult.SOME_NOTRUN);
 
-		JTabbedPaneOperator tabs = new JTabbedPaneOperator(mainFrame, TAB_CAPTION);
-		if (tabs.getTabCount() != 2) {
-			fail("Wrong tab count after opening the same test suite twice");
-		}
+        JTabbedPaneOperator tabs = new JTabbedPaneOperator(mainFrame, TAB_CAPTION);
+        if (tabs.getTabCount() != 2) {
+            fail("Wrong tab count after opening the same test suite twice");
+        }
 
-		if (!tabs.getTitleAt(0).contains(TAB_CAPTION) || !tabs.getTitleAt(1).contains(TAB_CAPTION)) {
-			fail("Tabs opened from the same teststuite have different captions");
-		}
-	}
+        if (!tabs.getTitleAt(0).contains(TAB_CAPTION) || !tabs.getTitleAt(1).contains(TAB_CAPTION)) {
+            fail("Tabs opened from the same teststuite have different captions");
+        }
+    }
 
 }

--- a/gui-tests/src/gui/src/jthtest/OpenTestSuite/OpenTestSuite2.java
+++ b/gui-tests/src/gui/src/jthtest/OpenTestSuite/OpenTestSuite2.java
@@ -1,0 +1,65 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.OpenTestSuite;
+
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JTabbedPaneOperator;
+
+public class OpenTestSuite2 extends OpenTestSuite {
+
+	/**
+	 * This test case verifies that opening an existing test suite twice would not
+	 * cause an error.
+	 */
+
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.OpenTestSuite.OpenTestSuite2");
+	}
+
+	@Test
+	public void testOpenTestSuite2() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+		openTestSuite(mainFrame);
+		openTestSuite(mainFrame);
+		waitForWDLoading(mainFrame, WDLoadingResult.SOME_NOTRUN);
+
+		JTabbedPaneOperator tabs = new JTabbedPaneOperator(mainFrame, TAB_CAPTION);
+		if (tabs.getTabCount() != 2) {
+			fail("Wrong tab count after opening the same test suite twice");
+		}
+
+		if (!tabs.getTitleAt(0).contains(TAB_CAPTION) || !tabs.getTitleAt(1).contains(TAB_CAPTION)) {
+			fail("Tabs opened from the same teststuite have different captions");
+		}
+	}
+
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.OpenTestSuite1.java
2.OpenTestSuite2.java
3.CreateWorkdir03.java
4.CreateWorkdir14.java
5.CreateWorkdir21.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903268](https://bugs.openjdk.org/browse/CODETOOLS-7903268): Feature Tests - Adding five JavaTest GUI legacy automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jtharness pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/37.diff">https://git.openjdk.org/jtharness/pull/37.diff</a>

</details>
