### PR TITLE
6734346: harness reads too many files

### DIFF
--- a/src/com/sun/javatest/report/PlainTextReport.java
+++ b/src/com/sun/javatest/report/PlainTextReport.java
@@ -61,20 +61,12 @@ public class PlainTextReport implements ReportFormat {
 
     @Override
     public ReportLink write(ReportSettings s, File dir) throws IOException {
-        TestResultTable resultTable = s.getInterview().getWorkDirectory().getTestResultTable();
-
-        File[] initFiles = s.getInitialFiles();
-
         SortedSet<TestResult> tests = new TreeSet<>(new TestResultsByFileComparator());
         int width = 0;
 
         Iterator<TestResult> iter = null;
         try {
-            if (initFiles == null) {
-                iter = resultTable.getIterator(s.filter);
-            } else {
-                iter = resultTable.getIterator(initFiles, s.filter);
-            }
+            iter = s.getIterator(s.filter);
         } catch (TestResultTable.Fault f) {
             throw new JavaTestError(i18n.getString("report.testResult.err"));
         }   // catch

--- a/src/com/sun/javatest/report/ReportSettings.java
+++ b/src/com/sun/javatest/report/ReportSettings.java
@@ -447,6 +447,22 @@ public class ReportSettings {
         return null;
     }
 
+    public TestResultTable.TreeIterator getIterator(TestFilter... testFilters)
+            throws TestResultTable.Fault {
+        TestResultTable resultTable = interviewParameters.getWorkDirectory().getTestResultTable();
+        File[] initFiles = getInitialFiles();
+        if (initFiles != null) {
+            return resultTable.getIterator(initFiles, testFilters);
+        }
+        if (interviewParameters != null) {
+            String[] tests = interviewParameters.getTests();
+            if (tests != null) {
+                return resultTable.getIterator(tests, testFilters);
+            }
+        }
+        return resultTable.getIterator(testFilters);
+    }
+
     public TestFilter getTestFilter() {
         return filter;
     }
@@ -504,8 +520,6 @@ public class ReportSettings {
         if (sortedTestResults != null) {
             return;
         }
-        TestResultTable resultTable = interviewParameters.getWorkDirectory().getTestResultTable();
-        File[] initFiles = getInitialFiles();
         sortedTestResults = new ArrayList<>();
         for (int i = 0; i < Status.NUM_STATES; i++) {
             sortedTestResults.add(new TreeSet<>(new TestResultsByNameComparator()));
@@ -520,7 +534,7 @@ public class ReportSettings {
             } else {
                 testFilters = new TestFilter[]{filter};
             }
-            testResultIterator = (initFiles == null) ? resultTable.getIterator(testFilters) : resultTable.getIterator(initFiles, testFilters);
+            testResultIterator = getIterator(testFilters);
         } catch (TestResultTable.Fault f) {
             throw new JavaTestError(ReportSettings.i18n.getString("result.testResult.err"));
         }

--- a/src/com/sun/javatest/report/ResultSection.java
+++ b/src/com/sun/javatest/report/ResultSection.java
@@ -57,8 +57,6 @@ class ResultSection extends HTMLSection {
     private final I18NResourceBundle i18n;
     private final String[] headings;
     List<TreeSet<TestResult>> testResults;
-    private TestResultTable resultTable;
-    private File[] initFiles;
     private int totalFound;
 
     ResultSection(HTMLReport parent, ReportSettings settings, File dir, I18NResourceBundle i18n,
@@ -73,14 +71,15 @@ class ResultSection extends HTMLSection {
                 i18n.getString("result.heading.notRun")
         };
 
-        resultTable = settings.getInterview().getWorkDirectory().getTestResultTable();
-        initFiles = settings.getInitialFiles();
         testResults = sortedResults;
 
         for (TreeSet<TestResult> s : sortedResults) {
             totalFound += s.size();
         }
         /*
+        TestResultTable resultTable = settings.getInterview().getWorkDirectory().getTestResultTable();
+        File[] initFiles = settings.getInitialFiles();
+
         lists = new TreeSet[Status.NUM_STATES];
         for (int i = 0; i < lists.length; i++ )
             lists[i] = new TreeSet(new TestResultsByNameComparator());

--- a/src/com/sun/javatest/report/StatisticsSection.java
+++ b/src/com/sun/javatest/report/StatisticsSection.java
@@ -47,8 +47,6 @@ import java.util.Vector;
 class StatisticsSection extends HTMLSection {
     private final I18NResourceBundle i18n;
     private final String[] headings;
-    private TestResultTable resultTable;
-    private File[] initFiles;
 
     //-----------------------------------------------------------------------
     private Map<String, int[]> keywordTable = new HashMap<>();
@@ -63,14 +61,9 @@ class StatisticsSection extends HTMLSection {
                 i18n.getString("stats.heading.error"),
                 i18n.getString("stats.heading.notRun")};
 
-        initFiles = settings.getInitialFiles();
-
-        resultTable = settings.getInterview().getWorkDirectory().getTestResultTable();
         Iterator<TestResult> iter = null;
         try {
-            iter = (initFiles == null) ?
-                    resultTable.getIterator(settings.filter) :
-                    resultTable.getIterator(initFiles, settings.filter);
+            iter = settings.getIterator(settings.filter);
         } catch (TestResultTable.Fault f) {
             throw new JavaTestError(i18n.getString("stats.testResult.err"));
         }       // catch

--- a/src/com/sun/javatest/report/XMLReport.java
+++ b/src/com/sun/javatest/report/XMLReport.java
@@ -148,16 +148,10 @@ public class XMLReport implements ReportFormat {
     private void writeResults(XMLReportMaker maker, ReportSettings sett) throws SAXException, JavaTestError, IOException {
         maker.sTestResults();
 
-        File[] initFiles = sett.getInitialFiles();
         Iterator<TestResult> iter = null;
-        TestResultTable resultTable = sett.getInterview().getWorkDirectory().getTestResultTable();
 
         try {
-            if (initFiles == null) {
-                iter = resultTable.getIterator(sett.getTestFilter());
-            } else {
-                iter = resultTable.getIterator(initFiles, sett.getTestFilter());
-            }
+            iter = sett.getIterator(sett.getTestFilter());
             for (; iter.hasNext(); ) {
                 TestResult tr = iter.next();
                 writeResult(maker, tr);


### PR DESCRIPTION
This patch fixes a long-standing issue where jtreg reads every java file under a test root (like test/jdk) when generating reports for jobs running a subset of tests.
On a Windows machine, this reduces the time required to run a single (fast) test and generate report from 15-20 seconds to 1-3 seconds.

Verified that the generated report looks correct; the report only contains tests that were actually run, so the extra work in scanning every java file was unnecessary.

Did not verify if the existing tests still pass; I'm new to ant, and couldn't get it to run the tests. Are there any instructions I could use?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-6734346](https://bugs.openjdk.org/browse/CODETOOLS-6734346): harness reads too many files


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jtharness pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/38.diff">https://git.openjdk.org/jtharness/pull/38.diff</a>

</details>
