### PR TITLE
7903330: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/CustomReport/CReport.java
+++ b/gui-tests/src/gui/src/jthtest/CustomReport/CReport.java
@@ -1,0 +1,64 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CustomReport;
+
+import jthtest.ReportTools;
+import jthtest.Test;
+import jthtest.tools.JTFrame;
+import jthtest.tools.ReportDialog;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public abstract class CReport extends Test {
+    private String path;
+    private boolean html;
+    private boolean plain;
+    private boolean xml;
+
+    public CReport(boolean html, boolean plain, boolean xml) {
+        this.html = html;
+        this.plain = plain;
+        this.xml = xml;
+        path = TEMP_PATH + REPORT_NAME + (html ? ReportTools.REPORT_POSTFIX_HTML : "") + (plain ? ReportTools.REPORT_POSTFIX_PLAIN : "") + (xml ? ReportTools.REPORT_POSTFIX_XML : "");
+    }
+
+    @Override
+    public void testImpl() throws Exception {
+        mainFrame = JTFrame.startJTWithDefaultWorkDirectory();
+
+        ReportDialog rd = mainFrame.openReportDialog();
+        rd.setHtmlChecked(html);
+        rd.setPlainChecked(plain);
+        rd.setXmlChecked(xml);
+        rd.setPath(path);
+        rd.pushCreate();
+        new JButtonOperator(ReportDialog.findShowReportDialog(), "Yes").push();
+
+        JDialogOperator report = new JDialogOperator(ReportTools.getExecResource("rb.title"));
+        CustomReport.checkReportBrowser(report, path, html, plain, xml);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport.java
+++ b/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport.java
@@ -1,0 +1,91 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CustomReport;
+
+import jthtest.ReportTools;
+import java.io.File;
+import javax.swing.JCheckBox;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JEditorPaneOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class CustomReport extends ReportTools {
+    public static JCheckBox selectType(JDialogOperator rep, ReportType sel) {
+    JListOperator types = new JListOperator(rep, new NameComponentChooser("nrd.typel"));
+    int index = 0;
+/*    switch(sel) {
+        case HTML: index = 0; break;
+        case PLAIN_TEXT: index = 1; break;
+        case XML: index = 2; break;
+        case CUSTOM_TEXT: index = 3; break;
+        case CUSTOM_XML: index = 4; break;
+    }/**/
+    index = sel.ordinal();
+    types.setSelectedIndex(index);
+    return (JCheckBox) types.getModel().getElementAt(index);
+    }
+
+    public static boolean checkReportFile(String path, ReportType type) {
+    String name = "";
+    switch(type) {
+        case HTML: name = File.separator+"html"+File.separator+"report.html"; break;
+        case PLAIN_TEXT: name = File.separator+"text"+File.separator+"summary.txt"; break;
+        case XML: name = File.separator+"xml"+File.separator+"report.xml"; break;
+    }
+    return new File(path+name).exists();
+    }
+
+    public static void checkReportBrowser(JDialogOperator report, String path,  boolean html, boolean plaintext, boolean xml) throws InterruptedException {
+    JEditorPaneOperator text = new JEditorPaneOperator(report, new NameComponentChooser("text"));
+
+    if(html) {
+        Thread.sleep(500);
+        if(!text.getText().trim().replaceAll("\\s+", " ").contains("HTML Report"))
+        throw new JemmyException("'HTML Report' hyperlink was not found in the report");
+        if(!checkReportFile(path, ReportType.HTML))
+        throw new JemmyException("Html report file was not found");
+    }
+
+    if(plaintext) {
+        Thread.sleep(500);
+        if(!text.getText().trim().replaceAll("\\s+", " ").contains("Plain Text Report"))
+        throw new JemmyException("'Plain Text Report' hyperlink was not found in the report");
+        if(!checkReportFile(path, ReportType.PLAIN_TEXT))
+        throw new JemmyException("Plain text report file was not found");
+    }
+
+    if(xml) {
+        Thread.sleep(500);
+        if(!text.getText().trim().replaceAll("\\s+", " ").contains("XML Report"))
+        throw new JemmyException("'XML Report' hyperlink was not found in the report");
+        if(!checkReportFile(path, ReportType.XML))
+        throw new JemmyException("xml report file was not found");
+    }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport1.java
+++ b/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport1.java
@@ -1,0 +1,38 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CustomReport;
+
+/**
+ * This test case verifies that report can be generated in html format.
+ */
+
+public class CustomReport1 extends CReport {
+
+    public CustomReport1() {
+        super(true, false, false);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport2.java
+++ b/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport2.java
@@ -1,0 +1,38 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CustomReport;
+
+/**
+ * This test case verifies that report can be generated in xml format.
+ */
+
+public class CustomReport2 extends CReport {
+
+    public CustomReport2() {
+        super(false, false, true);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport3.java
+++ b/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport3.java
@@ -1,0 +1,37 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CustomReport;
+
+/**
+ * This test case verifies that report can be generated in plain text format.
+ */
+public class CustomReport3 extends CReport {
+
+    public CustomReport3() {
+        super(false, true, false);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport4.java
+++ b/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport4.java
@@ -1,0 +1,39 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CustomReport;
+
+/**
+ * This test case verifies that report can be generated in xml and plain text
+ * format.
+ */
+
+public class CustomReport4 extends CReport {
+
+    public CustomReport4() {
+        super(false, true, true);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport5.java
+++ b/gui-tests/src/gui/src/jthtest/CustomReport/CustomReport5.java
@@ -1,0 +1,38 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CustomReport;
+
+/**
+ * This test case verifies that report can be generated in html and xml format.
+ */
+
+public class CustomReport5 extends CReport {
+
+    public CustomReport5() {
+        super(true, false, true);
+    }
+}


### PR DESCRIPTION
<!--
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8.

1.CustomReport1.java
2.CustomReport2.java
3.CustomReport3.java
4.CustomReport4.java
5.CustomReport5.java
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903330](https://bugs.openjdk.org/browse/CODETOOLS-7903330): Feature Tests - Adding five JavaTest GUI legacy automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/jtharness pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/39.diff">https://git.openjdk.org/jtharness/pull/39.diff</a>

</details>
