### PR TITLE
7903375: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Markers/Markers4.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers4.java
@@ -58,3 +58,4 @@ public class Markers4 extends Test {
 
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers4.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers4.java
@@ -29,7 +29,6 @@ package jthtest.Markers;
 /**
  * This test case verifies that a question could be marked from a popup menu.
  */
-
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.Icon;
 import jthtest.Test;

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers4.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers4.java
@@ -26,9 +26,6 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that a question could be marked from a popup menu.
- */
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.Icon;
 import jthtest.Test;
@@ -36,6 +33,9 @@ import jthtest.tools.ConfigDialog;
 import jthtest.tools.Configuration;
 import jthtest.tools.JTFrame;
 
+/**
+ * This test case verifies that a question could be marked from a popup menu.
+ */
 public class Markers4 extends Test {
 
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers4.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers4.java
@@ -1,0 +1,60 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that a question could be marked from a popup menu.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.Icon;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Markers4 extends Test {
+
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration config = mainFrame.getConfiguration();
+        config.load(CONFIG_NAME, true);
+        ConfigDialog cd = config.openByKey();
+
+        cd.getBookmarks_EnableBookmarks().push();
+        Icon emptyIcon = cd.getIcon(1);
+        cd.setBookmarkedByPopup(1);
+        if (cd.getIcon(1) == emptyIcon) {
+            errors.add("Icon wasn't found");
+        }
+        warnings.add("predefined warning: popup menu doesn't open without left clicking");
+
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers5.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers5.java
@@ -29,17 +29,18 @@ package jthtest.Markers;
 /**
  * This test case verifies that a question could be unmarked from a popup menu.
  */
-
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.Icon;
+
 import jthtest.Config_Edit.Config_Edit;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.netbeans.jemmy.JemmyException;
 import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
+import static jthtest.Markers.Markers.*;
 
-public class Markers5 extends Markers {
+public class Markers5 {
     public static void main(String args[]) {
         JUnitCore.main("jthtest.gui.Markers.Markers5");
     }
@@ -68,7 +69,6 @@ public class Markers5 extends Markers {
         if (getIcon(config, 1) != emptyIcon) {
             throw new JemmyException("Icon was found after unmarking");
         }
-
     }
 }
 

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers5.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers5.java
@@ -71,3 +71,4 @@ public class Markers5 extends Markers {
 
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers5.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers5.java
@@ -1,0 +1,73 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that a question could be unmarked from a popup menu.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.Icon;
+import jthtest.Config_Edit.Config_Edit;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class Markers5 extends Markers {
+    public static void main(String args[]) {
+        JUnitCore.main("jthtest.gui.Markers.Markers5");
+    }
+
+    @Test
+    public void testMarkers5() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        startJavatestNewDesktop();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        closeQS(mainFrame);
+        openTestSuite(mainFrame);
+        createWorkDirInTemp(mainFrame);
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+        Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+        openConfigDialogByKey(mainFrame);
+        JDialogOperator config = findConfigEditor(mainFrame);
+
+        pushEnableBookmarks(config);
+        Icon emptyIcon = getIcon(config, 1);
+        setBookmarkedByPopup(config, 1);
+        if (getIcon(config, 1) == emptyIcon)
+            throw new JemmyException("Icon wasn't found");
+        unsetBookmarkedByPopup(config, 1);
+        if (getIcon(config, 1) != emptyIcon) {
+            throw new JemmyException("Icon was found after unmarking");
+        }
+
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers5.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers5.java
@@ -26,12 +26,8 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that a question could be unmarked from a popup menu.
- */
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.Icon;
-
 import jthtest.Config_Edit.Config_Edit;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
@@ -40,6 +36,9 @@ import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import static jthtest.Markers.Markers.*;
 
+/**
+ * This test case verifies that a question could be unmarked from a popup menu.
+ */
 public class Markers5 {
     public static void main(String args[]) {
         JUnitCore.main("jthtest.gui.Markers.Markers5");

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers6.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers6.java
@@ -39,7 +39,6 @@ import org.netbeans.jemmy.operators.JFrameOperator;
  * This test case verifies that selecting show marked questions will only
  * display the list of marked questions in the interview.
  */
-
 public class Markers6 extends Test {
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
         mainFrame = new JTFrame(true);

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers6.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers6.java
@@ -59,3 +59,4 @@ public class Markers6 extends Test {
         cd.checkVisibility(names);
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers6.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers6.java
@@ -1,0 +1,61 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+/**
+ * This test case verifies that selecting show marked questions will only
+ * display the list of marked questions in the interview.
+ */
+
+public class Markers6 extends Test {
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
+        ConfigDialog cd = configuration.openByKey();
+
+        cd.getBookmarks_EnableBookmarks().push();
+        int[] indexes = new int[] { 1, 2 };
+        cd.setBookmarkedByMenu(indexes);
+        String names[] = cd.getElementsNames(indexes);
+        cd.getBookmarks_ShowOnlyBookmarkedMenu().push();
+
+        cd.checkVisibility(names);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers7.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers7.java
@@ -26,15 +26,15 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies unselecting show marked questions will display the whole list of questions in the interview.
- */
 import java.lang.reflect.InvocationTargetException;
 import jthtest.Test;
 import jthtest.tools.ConfigDialog;
 import jthtest.tools.Configuration;
 import jthtest.tools.JTFrame;
 
+/**
+ * This test case verifies unselecting show marked questions will display the whole list of questions in the interview.
+ */
 public class Markers7 extends Test {
 
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers7.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers7.java
@@ -60,3 +60,4 @@ public class Markers7 extends Test {
         cd.checkVisibilityAll(allNames);
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers7.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers7.java
@@ -29,7 +29,6 @@ package jthtest.Markers;
 /**
  * This test case verifies unselecting show marked questions will display the whole list of questions in the interview.
  */
-
 import java.lang.reflect.InvocationTargetException;
 import jthtest.Test;
 import jthtest.tools.ConfigDialog;

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers7.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers7.java
@@ -1,0 +1,62 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies unselecting show marked questions will display the whole list of questions in the interview.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Markers7 extends Test {
+
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
+        ConfigDialog cd = configuration.openByKey();
+
+        cd.getBookmarks_EnableBookmarks().push();
+        int[] indexes = new int[] { 1, 2 };
+        String allNames[] = cd.getElementsNames();
+        String bookmarkedNames[] = cd.getElementsNames(indexes);
+
+        cd.setBookmarkedByMenu(indexes);
+        cd.getBookmarks_ShowOnlyBookmarkedMenu().push();
+        cd.checkVisibility(bookmarkedNames);
+
+        cd.getBookmarks_ShowOnlyBookmarkedMenu().push();
+        cd.checkVisibilityAll(allNames);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers8.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers8.java
@@ -29,7 +29,6 @@ package jthtest.Markers;
 /**
  * This test case verifies that unmark current question will remove the markers from the marked question.
  */
-
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.Icon;
 import jthtest.Test;

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers8.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers8.java
@@ -26,9 +26,6 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that unmark current question will remove the markers from the marked question.
- */
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.Icon;
 import jthtest.Test;
@@ -36,6 +33,9 @@ import jthtest.tools.ConfigDialog;
 import jthtest.tools.Configuration;
 import jthtest.tools.JTFrame;
 
+/**
+ * This test case verifies that unmark current question will remove the markers from the marked question.
+ */
 public class Markers8 extends Test {
 
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers8.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers8.java
@@ -1,0 +1,61 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that unmark current question will remove the markers from the marked question.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.Icon;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Markers8 extends Test {
+
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
+        ConfigDialog cd = configuration.openByKey();
+
+        cd.getBookmarks_EnableBookmarks().push();
+        Icon emptyIcon = cd.getIcon(1);
+        cd.setBookmarkedByMenu(1);
+        if (cd.getIcon(1) == emptyIcon)
+            errors.add("Bookmark Icon was not found after marking");
+
+        cd.unsetBookmarkedByMenu(1);
+        if (cd.getIcon(1) != emptyIcon)
+            errors.add("Empty Icon was not found after unmarking");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers8.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers8.java
@@ -59,3 +59,4 @@ public class Markers8 extends Test {
             errors.add("Empty Icon was not found after unmarking");
     }
 }
+


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1.Markers4.java
2.Markers5.java
3.Markers6.java
4.Markers7.java
5.Markers8.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903375](https://bugs.openjdk.org/browse/CODETOOLS-7903375): Feature Tests - Adding five JavaTest GUI legacy automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.org/jtharness pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/42.diff">https://git.openjdk.org/jtharness/pull/42.diff</a>

</details>
