### PR TITLE
7903376: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Markers/Markers10.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers10.java
@@ -26,10 +26,6 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that selecting clear the response to the current question button will clear the answer to that question.
- */
-
 import java.lang.reflect.InvocationTargetException;
 import jthtest.Test;
 import jthtest.tools.ConfigDialog;
@@ -39,7 +35,10 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 import org.netbeans.jemmy.util.NameComponentChooser;
 
 public class Markers10 extends Test {
-
+    /**
+     * This test case verifies that selecting clear the response to the current
+     * question button will clear the answer to that question.
+     */
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
         mainFrame = new JTFrame(true);
 
@@ -64,4 +63,3 @@ public class Markers10 extends Test {
                 "Pre-defined warning: Mark sometimes desapperas while clearing by menu - bookmark saves current state of answer; First question is 'Configuratoin name' and it can't be cleared; a new question is generated while clearing up");
     }
 }
-

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers10.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers10.java
@@ -1,0 +1,66 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that selecting clear the response to the current question button will clear the answer to that question.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class Markers10 extends Test {
+
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
+        ConfigDialog cd = configuration.openByKey();
+
+        cd.getBookmarks_EnableBookmarks().push();
+        cd.selectQuestion(2);
+        JTextFieldOperator op = new JTextFieldOperator(cd.getConfigDialog(), new NameComponentChooser("str.txt"));
+        op.typeText("some description that must be cleared");
+        cd.setBookmarkedByMenu(2);
+        cd.clearByMenu(2);
+
+        op = new JTextFieldOperator(cd.getConfigDialog(), new NameComponentChooser("str.txt"));
+        if (!op.getText().equals("")) {
+            errors.add("Text wasn't cleared up: '" + op.getText() + "' while expected ''");
+        }
+        warnings.add(
+                "Pre-defined warning: Mark sometimes desapperas while clearing by menu - bookmark saves current state of answer; First question is 'Configuratoin name' and it can't be cleared; a new question is generated while clearing up");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers10.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers10.java
@@ -64,3 +64,4 @@ public class Markers10 extends Test {
                 "Pre-defined warning: Mark sometimes desapperas while clearing by menu - bookmark saves current state of answer; First question is 'Configuratoin name' and it can't be cleared; a new question is generated while clearing up");
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers11.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers11.java
@@ -26,12 +26,8 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that answer for current question could be cleared from a popup menu.
- */
-
 import java.lang.reflect.InvocationTargetException;
-import jthtest.Config_Edit.Config_Edit;
+import static jthtest.Config_Edit.Config_Edit.*;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.netbeans.jemmy.JemmyException;
@@ -41,10 +37,15 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 import org.netbeans.jemmy.util.NameComponentChooser;
 
 public class Markers11 extends Markers {
+    /**
+     * This test case verifies that answer for current question could be cleared
+     * from a popup menu.
+     */
     public static void main(String args[]) {
         JUnitCore.main("jthtest.gui.Markers.Markers11");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMarkers11() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
         startJavatestNewDesktop();
@@ -55,7 +56,7 @@ public class Markers11 extends Markers {
         openTestSuite(mainFrame);
         createWorkDirInTemp(mainFrame);
         openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
-        Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+        waitForConfigurationLoading(mainFrame, CONFIG_NAME);
 
         openConfigDialogByKey(mainFrame);
         JDialogOperator config = findConfigEditor(mainFrame);
@@ -76,4 +77,3 @@ public class Markers11 extends Markers {
                 "Pre-defined warning: Mark sometimes desapperas while clearing by menu - bookmark saves current state of answer; First question is 'Configuratoin name' and it can't be cleared; a new question is generated while clearing up");
     }
 }
-

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers11.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers11.java
@@ -76,3 +76,4 @@ public class Markers11 extends Markers {
                 "Pre-defined warning: Mark sometimes desapperas while clearing by menu - bookmark saves current state of answer; First question is 'Configuratoin name' and it can't be cleared; a new question is generated while clearing up");
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers11.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers11.java
@@ -1,0 +1,78 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that answer for current question could be cleared from a popup menu.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Config_Edit.Config_Edit;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class Markers11 extends Markers {
+    public static void main(String args[]) {
+        JUnitCore.main("jthtest.gui.Markers.Markers11");
+    }
+
+    @Test
+    public void testMarkers11() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        startJavatestNewDesktop();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        closeQS(mainFrame);
+        openTestSuite(mainFrame);
+        createWorkDirInTemp(mainFrame);
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+        Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+        openConfigDialogByKey(mainFrame);
+        JDialogOperator config = findConfigEditor(mainFrame);
+
+        pushEnableBookmarks(config);
+
+        selectQuestion(config, 2);
+        new JTextFieldOperator(config, new NameComponentChooser("str.txt"))
+                .typeText("some description that must be cleared");
+        setBookmarkedByMenu(config, 2);
+        clearByPopup(config, 2);
+
+        if (!new JTextFieldOperator(config, new NameComponentChooser("str.txt")).getText().equals(""))
+            throw new JemmyException("Text wasn't cleared up: '"
+                    + new JTextFieldOperator(config, new NameComponentChooser("str.txt")).getText()
+                    + "' while expected ''");
+        System.out.println(
+                "Pre-defined warning: Mark sometimes desapperas while clearing by menu - bookmark saves current state of answer; First question is 'Configuratoin name' and it can't be cleared; a new question is generated while clearing up");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers12.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers12.java
@@ -26,22 +26,19 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that not responding to the cleared response of the current question will display an invalid answer.
- */
-
 import java.lang.reflect.InvocationTargetException;
 import jthtest.Test;
-import jthtest.Tools;
 import jthtest.tools.ConfigDialog;
 import jthtest.tools.Configuration;
 import jthtest.tools.JTFrame;
-import org.netbeans.jemmy.JemmyException;
 import org.netbeans.jemmy.operators.JTextFieldOperator;
 import org.netbeans.jemmy.util.NameComponentChooser;
 
 public class Markers12 extends Test {
-
+    /**
+     * This test case verifies that not responding to the cleared response of the
+     * current question will display an invalid answer.
+     */
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
         mainFrame = new JTFrame(true);
 
@@ -67,4 +64,3 @@ public class Markers12 extends Test {
         warnings.add("Pre-defined warning: Some questions can be optional and some can have default value");
     }
 }
-

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers12.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers12.java
@@ -1,0 +1,69 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that not responding to the cleared response of the current question will display an invalid answer.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class Markers12 extends Test {
+
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
+
+        ConfigDialog config = configuration.openByKey();
+
+        config.getBookmarks_EnableBookmarks().push();
+        config.setBookmarkedByMenu(4);
+        config.clearByMenu(4);
+        config.pushNextConfigEditor();
+
+        if (!new JTextFieldOperator(config.getConfigDialog(), new NameComponentChooser("qu.vmsg")).getText()
+                .equals("Invalid response")) {
+            errors.add("Error message wasn't found: '"
+                    + new JTextFieldOperator(config.getConfigDialog(), new NameComponentChooser("qu.vmsg")).getText()
+                    + "' while expected 'Invalud response'");
+        }
+
+        warnings.add("Pre-defined warning: Some questions can be optional and some can have default value");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers12.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers12.java
@@ -67,3 +67,4 @@ public class Markers12 extends Test {
         warnings.add("Pre-defined warning: Some questions can be optional and some can have default value");
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers13.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers13.java
@@ -1,0 +1,62 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that the Show only Marked Questions will create a sequences of "..." for marked questions.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Markers13 extends Test {
+
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
+
+        ConfigDialog config = configuration.openByKey();
+
+        int[] indexes = new int[] { 2, 3, 4, 7, 8, 10 };
+        String[] names = config.getElementsNames(indexes);
+
+        config.getBookmarks_EnableBookmarks().push();
+        config.setBookmarkedByMenu(indexes);
+        config.getBookmarks_ShowOnlyBookmarkedMenu().push();
+
+        indexes = config.checkVisibility(names);
+        config.checkHiddenGroups(indexes, names);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers13.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers13.java
@@ -26,19 +26,17 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that the Show only Marked Questions will create a sequences of "..." for marked questions.
- */
-
 import java.lang.reflect.InvocationTargetException;
 import jthtest.Test;
-import jthtest.Tools;
 import jthtest.tools.ConfigDialog;
 import jthtest.tools.Configuration;
 import jthtest.tools.JTFrame;
 
 public class Markers13 extends Test {
-
+    /**
+     * This test case verifies that the Show only Marked Questions will create a
+     * sequences of "..." for marked questions.
+     */
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
         mainFrame = new JTFrame(true);
 
@@ -60,4 +58,3 @@ public class Markers13 extends Test {
         config.checkHiddenGroups(indexes, names);
     }
 }
-

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers13.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers13.java
@@ -60,3 +60,4 @@ public class Markers13 extends Test {
         config.checkHiddenGroups(indexes, names);
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers9.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers9.java
@@ -26,10 +26,6 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that marked question could be unmarked from a popup menu.
- */
-
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.Icon;
 import jthtest.Test;
@@ -38,6 +34,10 @@ import jthtest.tools.Configuration;
 import jthtest.tools.JTFrame;
 
 public class Markers9 extends Test {
+    /**
+     * This test case verifies that marked question could be unmarked from a popup
+     * menu.
+     */
     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
         mainFrame = new JTFrame(true);
 
@@ -58,4 +58,3 @@ public class Markers9 extends Test {
             errors.add("Empty Icon was not found after unmarking");
     }
 }
-

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers9.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers9.java
@@ -58,3 +58,4 @@ public class Markers9 extends Test {
             errors.add("Empty Icon was not found after unmarking");
     }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers9.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers9.java
@@ -1,0 +1,60 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that marked question could be unmarked from a popup menu.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.Icon;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Markers9 extends Test {
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
+        ConfigDialog cd = configuration.openByKey();
+
+        cd.getBookmarks_EnableBookmarks().push();
+        Icon emptyIcon = cd.getIcon(1);
+        cd.setBookmarkedByMenu(1);
+        if (cd.getIcon(1) == emptyIcon)
+            errors.add("Bookmark Icon was not found after marking");
+
+        cd.unsetBookmarkedByPopup(1);
+        if (cd.getIcon(1) != emptyIcon)
+            errors.add("Empty Icon was not found after unmarking");
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macOS.

1.Markers9.java
2.Markers10.java
3.Markers11.java
4.Markers12.java
5.Markers13.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903376](https://bugs.openjdk.org/browse/CODETOOLS-7903376): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/jtharness.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/43.diff">https://git.openjdk.org/jtharness/pull/43.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/43#issuecomment-1289565475)