### PR TITLE
7903442: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Markers/Markers19.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers19.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Markers;
+
+/**
+ * This test case verifies that double clicking on a "..." entry will open the group of questions that it represents.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Markers19 extends Test {
+
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
+
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
+
+        ConfigDialog config = configuration.openByKey();
+
+        int[] indexes = new int[] { 4, 5, 6, 8, 9 };
+        config.getBookmarks_EnableBookmarks().push();
+
+        config.setBookmarkedByMenu(indexes);
+        String[] namesAll = config.getElementsNames();
+        config.getBookmarks_ShowOnlyBookmarkedMenu().push();
+        String namesHidden[] = config.getElementsNames();
+
+        config.openGroupByMouse(namesAll, namesHidden);
+
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers19.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers19.java
@@ -33,30 +33,30 @@ import jthtest.tools.Configuration;
 import jthtest.tools.JTFrame;
 
 public class Markers19 extends Test {
-	/**
-	 * This test case verifies that double clicking on a "..." entry will open the
-	 * group of questions that it represents.
-	 */
-	public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
-		mainFrame = new JTFrame(true);
+    /**
+     * This test case verifies that double clicking on a "..." entry will open the
+     * group of questions that it represents.
+     */
+    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        mainFrame = new JTFrame(true);
 
-		mainFrame.openDefaultTestSuite();
-		addUsedFile(mainFrame.createWorkDirectoryInTemp());
-		Configuration configuration = mainFrame.getConfiguration();
-		configuration.load(CONFIG_NAME, true);
+        mainFrame.openDefaultTestSuite();
+        addUsedFile(mainFrame.createWorkDirectoryInTemp());
+        Configuration configuration = mainFrame.getConfiguration();
+        configuration.load(CONFIG_NAME, true);
 
-		ConfigDialog config = configuration.openByKey();
+        ConfigDialog config = configuration.openByKey();
 
-		int[] indexes = new int[] { 4, 5, 6, 8, 9 };
-		config.getBookmarks_EnableBookmarks().push();
+        int[] indexes = new int[] { 4, 5, 6, 8, 9 };
+        config.getBookmarks_EnableBookmarks().push();
 
-		config.setBookmarkedByMenu(indexes);
-		String[] namesAll = config.getElementsNames();
-		config.getBookmarks_ShowOnlyBookmarkedMenu().push();
-		String namesHidden[] = config.getElementsNames();
+        config.setBookmarkedByMenu(indexes);
+        String[] namesAll = config.getElementsNames();
+        config.getBookmarks_ShowOnlyBookmarkedMenu().push();
+        String namesHidden[] = config.getElementsNames();
 
-		config.openGroupByMouse(namesAll, namesHidden);
+        config.openGroupByMouse(namesAll, namesHidden);
 
-	}
+    }
 
 }

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers19.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers19.java
@@ -26,10 +26,6 @@
  */
 package jthtest.Markers;
 
-/**
- * This test case verifies that double clicking on a "..." entry will open the group of questions that it represents.
- */
-
 import java.lang.reflect.InvocationTargetException;
 import jthtest.Test;
 import jthtest.tools.ConfigDialog;
@@ -37,27 +33,30 @@ import jthtest.tools.Configuration;
 import jthtest.tools.JTFrame;
 
 public class Markers19 extends Test {
+	/**
+	 * This test case verifies that double clicking on a "..." entry will open the
+	 * group of questions that it represents.
+	 */
+	public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+		mainFrame = new JTFrame(true);
 
-    public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
-        mainFrame = new JTFrame(true);
+		mainFrame.openDefaultTestSuite();
+		addUsedFile(mainFrame.createWorkDirectoryInTemp());
+		Configuration configuration = mainFrame.getConfiguration();
+		configuration.load(CONFIG_NAME, true);
 
-        mainFrame.openDefaultTestSuite();
-        addUsedFile(mainFrame.createWorkDirectoryInTemp());
-        Configuration configuration = mainFrame.getConfiguration();
-        configuration.load(CONFIG_NAME, true);
+		ConfigDialog config = configuration.openByKey();
 
-        ConfigDialog config = configuration.openByKey();
+		int[] indexes = new int[] { 4, 5, 6, 8, 9 };
+		config.getBookmarks_EnableBookmarks().push();
 
-        int[] indexes = new int[] { 4, 5, 6, 8, 9 };
-        config.getBookmarks_EnableBookmarks().push();
+		config.setBookmarkedByMenu(indexes);
+		String[] namesAll = config.getElementsNames();
+		config.getBookmarks_ShowOnlyBookmarkedMenu().push();
+		String namesHidden[] = config.getElementsNames();
 
-        config.setBookmarkedByMenu(indexes);
-        String[] namesAll = config.getElementsNames();
-        config.getBookmarks_ShowOnlyBookmarkedMenu().push();
-        String namesHidden[] = config.getElementsNames();
+		config.openGroupByMouse(namesAll, namesHidden);
 
-        config.openGroupByMouse(namesAll, namesHidden);
-
-    }
+	}
 
 }

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers20.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers20.java
@@ -1,0 +1,72 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Markers;
+
+/**
+ * This test case verifies that double clicking on a question that is displayed because it is part of ".." group will close the group so that is again show as "...".
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Config_Edit.Config_Edit;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class Markers20 extends Markers {
+    public static void main(String args[]) {
+        JUnitCore.main("jthtest.gui.Markers.Markers20");
+    }
+
+    @Test
+    public void testMarkers20() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        startJavatestNewDesktop();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        closeQS(mainFrame);
+        openTestSuite(mainFrame);
+        createWorkDirInTemp(mainFrame);
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+        Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+        openConfigDialogByKey(mainFrame);
+        JDialogOperator config = findConfigEditor(mainFrame);
+
+        int[] indexes = new int[] { 4, 5, 6, 8, 9 };
+
+        pushEnableBookmarks(config);
+        setBookmarkedByMenu(config, indexes);
+        String[] namesAll = getElementsNames(config);
+        pushShowOnlyBookmarked(config);
+        String[] namesHidden = getElementsNames(config);
+
+        openGroupByMouse(config, namesAll, namesHidden);
+        closeGroupByMouse(config, namesAll, namesHidden);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers20.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers20.java
@@ -35,39 +35,39 @@ import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 
 public class Markers20 extends Markers {
-	public static void main(String args[]) {
-		JUnitCore.main("jthtest.gui.Markers.Markers20");
-	}
+    public static void main(String args[]) {
+        JUnitCore.main("jthtest.gui.Markers.Markers20");
+    }
 
-	/**
-	 * This test case verifies that double clicking on a question that is displayed
-	 * because it is part of ".." group will close the group so that is again show
-	 * as "...".
-	 */
-	@Test
-	public void testMarkers20() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
-		startJavatestNewDesktop();
+    /**
+     * This test case verifies that double clicking on a question that is displayed
+     * because it is part of ".." group will close the group so that is again show
+     * as "...".
+     */
+    @Test
+    public void testMarkers20() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        startJavatestNewDesktop();
 
-		JFrameOperator mainFrame = findMainFrame();
+        JFrameOperator mainFrame = findMainFrame();
 
-		closeQS(mainFrame);
-		openTestSuite(mainFrame);
-		createWorkDirInTemp(mainFrame);
-		openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
-		Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+        closeQS(mainFrame);
+        openTestSuite(mainFrame);
+        createWorkDirInTemp(mainFrame);
+        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+        Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
 
-		openConfigDialogByKey(mainFrame);
-		JDialogOperator config = findConfigEditor(mainFrame);
+        openConfigDialogByKey(mainFrame);
+        JDialogOperator config = findConfigEditor(mainFrame);
 
-		int[] indexes = new int[] { 4, 5, 6, 8, 9 };
+        int[] indexes = new int[] { 4, 5, 6, 8, 9 };
 
-		pushEnableBookmarks(config);
-		setBookmarkedByMenu(config, indexes);
-		String[] namesAll = getElementsNames(config);
-		pushShowOnlyBookmarked(config);
-		String[] namesHidden = getElementsNames(config);
+        pushEnableBookmarks(config);
+        setBookmarkedByMenu(config, indexes);
+        String[] namesAll = getElementsNames(config);
+        pushShowOnlyBookmarked(config);
+        String[] namesHidden = getElementsNames(config);
 
-		openGroupByMouse(config, namesAll, namesHidden);
-		closeGroupByMouse(config, namesAll, namesHidden);
-	}
+        openGroupByMouse(config, namesAll, namesHidden);
+        closeGroupByMouse(config, namesAll, namesHidden);
+    }
 }

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers20.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers20.java
@@ -27,10 +27,6 @@
 
 package jthtest.Markers;
 
-/**
- * This test case verifies that double clicking on a question that is displayed because it is part of ".." group will close the group so that is again show as "...".
- */
-
 import java.lang.reflect.InvocationTargetException;
 import jthtest.Config_Edit.Config_Edit;
 import org.junit.Test;
@@ -39,34 +35,39 @@ import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 
 public class Markers20 extends Markers {
-    public static void main(String args[]) {
-        JUnitCore.main("jthtest.gui.Markers.Markers20");
-    }
+	public static void main(String args[]) {
+		JUnitCore.main("jthtest.gui.Markers.Markers20");
+	}
 
-    @Test
-    public void testMarkers20() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
-        startJavatestNewDesktop();
+	/**
+	 * This test case verifies that double clicking on a question that is displayed
+	 * because it is part of ".." group will close the group so that is again show
+	 * as "...".
+	 */
+	@Test
+	public void testMarkers20() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+		startJavatestNewDesktop();
 
-        JFrameOperator mainFrame = findMainFrame();
+		JFrameOperator mainFrame = findMainFrame();
 
-        closeQS(mainFrame);
-        openTestSuite(mainFrame);
-        createWorkDirInTemp(mainFrame);
-        openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
-        Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+		closeQS(mainFrame);
+		openTestSuite(mainFrame);
+		createWorkDirInTemp(mainFrame);
+		openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+		Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
 
-        openConfigDialogByKey(mainFrame);
-        JDialogOperator config = findConfigEditor(mainFrame);
+		openConfigDialogByKey(mainFrame);
+		JDialogOperator config = findConfigEditor(mainFrame);
 
-        int[] indexes = new int[] { 4, 5, 6, 8, 9 };
+		int[] indexes = new int[] { 4, 5, 6, 8, 9 };
 
-        pushEnableBookmarks(config);
-        setBookmarkedByMenu(config, indexes);
-        String[] namesAll = getElementsNames(config);
-        pushShowOnlyBookmarked(config);
-        String[] namesHidden = getElementsNames(config);
+		pushEnableBookmarks(config);
+		setBookmarkedByMenu(config, indexes);
+		String[] namesAll = getElementsNames(config);
+		pushShowOnlyBookmarked(config);
+		String[] namesHidden = getElementsNames(config);
 
-        openGroupByMouse(config, namesAll, namesHidden);
-        closeGroupByMouse(config, namesAll, namesHidden);
-    }
+		openGroupByMouse(config, namesAll, namesHidden);
+		closeGroupByMouse(config, namesAll, namesHidden);
+	}
 }

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate25.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate25.java
@@ -1,0 +1,71 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate25 extends Test {
+    /**
+     * This test case verifies that Cancel button in the Create Report Directory
+     * will dismiss the dialog box .
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        createFakeRepDir(path);
+        addUsedFile(path);
+
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport htmlReport = new HtmlReport(rep);
+        htmlReport.setOptionsAll(false);
+        htmlReport.setOptionsResults(true);
+        htmlReport.setFilesAll(false);
+        htmlReport.setFilesPutInReport(true);
+
+        setPath(rep, path);
+        new JButtonOperator(rep, "Cancel").push();
+
+        if (new File(path + "html~1~").exists()) {
+            throw new JemmyException("backup directory was created");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate26.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate26.java
@@ -1,0 +1,80 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate26 extends Test {
+    /**
+     * This test case verifies that Cancel button in the Create Report Directory
+     * will not save settings in the preferences file.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        createFakeRepDir(path);
+        addUsedFile(path);
+
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport htmlReport = new HtmlReport(rep, false);
+
+        setPath(rep, path);
+        pressCreate(rep);
+        new JButtonOperator(findShowReportDialog(), "No").push();
+
+        rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        htmlReport = new HtmlReport(rep);
+        htmlReport.setExtraBackUp(false);
+
+        new JButtonOperator(rep, "Cancel").push();
+
+        rep = openReportCreation(mainFrame);
+        htmlReport = new HtmlReport(rep, true);
+
+        if (!htmlReport.isEBackUp()) {
+            throw new JemmyException("configuration was saved");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate27.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate27.java
@@ -1,0 +1,68 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate27 extends Test {
+    /**
+     * This test case verifies that selecting the plain text for last test run
+     * filter will create the report in the text format for the last test run
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, true);
+        setHtmlChecked(rep, false);
+        chooseFilter(rep, FiltersType.LAST_TEST_RUN);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+        File f = new File(path);
+        deleteDirectory(f);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(f);
+        findShowReportDialog();
+
+        File plainReport = new File(path + "text" + File.separator + "summary.txt");
+        if (!plainReport.canRead()) {
+            throw new JemmyException("can't read text file");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate28.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate28.java
@@ -1,0 +1,68 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate28 extends Test {
+    /**
+     * This test case verifies that selecting the plain text for the custom filter
+     * will create the report in the text format for the created custom filter.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, true);
+        setHtmlChecked(rep, false);
+        chooseFilter(rep, FiltersType.CUSTOM);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+        File f = new File(path);
+        deleteDirectory(f);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(f);
+        findShowReportDialog();
+
+        File plainReport = new File(path + "text" + File.separator + "summary.txt");
+        if (!plainReport.canRead()) {
+            throw new JemmyException("can't read text file");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate29.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate29.java
@@ -1,0 +1,73 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class ReportCreate29 extends Test {
+    /**
+     * This test case verifies that selecting the custom filter in the report dialog
+     * could be modified and a report gets created.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, true);
+        setHtmlChecked(rep, false);
+        chooseFilter(rep, FiltersType.CUSTOM);
+        new JButtonOperator(rep, new NameComponentChooser("fconfig.config")).push();
+        JDialogOperator filter = new JDialogOperator(mainFrame, "Filter Editor");
+        new JButtonOperator(filter, "Cancel").push();
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+        File f = new File(path);
+        deleteDirectory(f);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(f);
+        findShowReportDialog();
+
+        File plainReport = new File(path + "text" + File.separator + "summary.txt");
+        if (!plainReport.canRead()) {
+            throw new JemmyException("can't read text file");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter2.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter2.java
@@ -27,12 +27,7 @@
 
 package jthtest.ViewFilter;
 
-/**
- * This test case verifies that current configuration filter can not be modified.
- */
-
 import java.lang.reflect.InvocationTargetException;
-
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.netbeans.jemmy.operators.JDialogOperator;
@@ -40,21 +35,25 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 
 public class ViewFilter2 extends ViewFilter {
 
-    public static void main(String[] args) {
-        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter2");
-    }
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter2");
+	}
 
-    @Test
-    public void testViewFilter2() throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+	/**
+	 * This test case verifies that current configuration filter can not be
+	 * modified.
+	 */
+	@Test
+	public void testViewFilter2() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-        startWithDefaultWorkdir();
+		startWithDefaultWorkdir();
 
-        JDialogOperator filterEditor = openFilterEditor(mainFrame);
+		JDialogOperator filterEditor = openFilterEditor(mainFrame);
 
-        selectFilter(filterEditor, 1);
+		selectFilter(filterEditor, 1);
 
-        new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
+		new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
 
-    }
+	}
 
 }

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter2.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter2.java
@@ -35,25 +35,25 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 
 public class ViewFilter2 extends ViewFilter {
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter2");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter2");
+    }
 
-	/**
-	 * This test case verifies that current configuration filter can not be
-	 * modified.
-	 */
-	@Test
-	public void testViewFilter2() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+    /**
+     * This test case verifies that current configuration filter can not be
+     * modified.
+     */
+    @Test
+    public void testViewFilter2() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-		startWithDefaultWorkdir();
+        startWithDefaultWorkdir();
 
-		JDialogOperator filterEditor = openFilterEditor(mainFrame);
+        JDialogOperator filterEditor = openFilterEditor(mainFrame);
 
-		selectFilter(filterEditor, 1);
+        selectFilter(filterEditor, 1);
 
-		new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
+        new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
 
-	}
+    }
 
 }

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter2.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter2.java
@@ -1,0 +1,60 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ViewFilter;
+
+/**
+ * This test case verifies that current configuration filter can not be modified.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+
+public class ViewFilter2 extends ViewFilter {
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter2");
+    }
+
+    @Test
+    public void testViewFilter2() throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+        startWithDefaultWorkdir();
+
+        JDialogOperator filterEditor = openFilterEditor(mainFrame);
+
+        selectFilter(filterEditor, 1);
+
+        new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
+
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter3.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter3.java
@@ -35,24 +35,24 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 
 public class ViewFilter3 extends ViewFilter {
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter3");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter3");
+    }
 
-	/**
-	 * This test case verifies that All Tests filter can not be modified.
-	 */
-	@Test
-	public void testViewFilter3() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+    /**
+     * This test case verifies that All Tests filter can not be modified.
+     */
+    @Test
+    public void testViewFilter3() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-		startWithDefaultWorkdir();
+        startWithDefaultWorkdir();
 
-		JDialogOperator filterEditor = openFilterEditor(mainFrame);
+        JDialogOperator filterEditor = openFilterEditor(mainFrame);
 
-		selectFilter(filterEditor, 2);
+        selectFilter(filterEditor, 2);
 
-		new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
+        new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
 
-	}
+    }
 
 }

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter3.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter3.java
@@ -1,0 +1,61 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ViewFilter;
+
+/**
+ * This test case verifies that All Tests filter can not be modified.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+
+public class ViewFilter3 extends ViewFilter {
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter3");
+    }
+
+    @Test
+    public void testViewFilter3()
+            throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+        startWithDefaultWorkdir();
+
+        JDialogOperator filterEditor = openFilterEditor(mainFrame);
+
+        selectFilter(filterEditor, 2);
+
+        new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
+
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter3.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter3.java
@@ -27,12 +27,7 @@
 
 package jthtest.ViewFilter;
 
-/**
- * This test case verifies that All Tests filter can not be modified.
- */
-
 import java.lang.reflect.InvocationTargetException;
-
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.netbeans.jemmy.operators.JDialogOperator;
@@ -40,22 +35,24 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 
 public class ViewFilter3 extends ViewFilter {
 
-    public static void main(String[] args) {
-        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter3");
-    }
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter3");
+	}
 
-    @Test
-    public void testViewFilter3()
-            throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+	/**
+	 * This test case verifies that All Tests filter can not be modified.
+	 */
+	@Test
+	public void testViewFilter3() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-        startWithDefaultWorkdir();
+		startWithDefaultWorkdir();
 
-        JDialogOperator filterEditor = openFilterEditor(mainFrame);
+		JDialogOperator filterEditor = openFilterEditor(mainFrame);
 
-        selectFilter(filterEditor, 2);
+		selectFilter(filterEditor, 2);
 
-        new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
+		new JTextFieldOperator(filterEditor, "Does not apply to this filter.");
 
-    }
+	}
 
 }

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter5.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter5.java
@@ -27,12 +27,7 @@
 
 package jthtest.ViewFilter;
 
-/**
- *This test case verifies that Custom filter can be modified.
- */
-
 import java.lang.reflect.InvocationTargetException;
-
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.netbeans.jemmy.operators.JDialogOperator;
@@ -40,24 +35,27 @@ import org.netbeans.jemmy.operators.JMenuOperator;
 
 public class ViewFilter5 extends ViewFilter {
 
-    public static void main(String[] args) {
-        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter5");
-    }
+	public static void main(String[] args) {
+		JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter5");
+	}
 
-    @Test
-    public void testViewFilter5()
-            throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+	/**
+	 * This test case verifies that enabling test suite filter in the configure
+	 * filter will update the custom filter.
+	 */
+	@Test
+	public void testViewFilter5() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-        startWithDefaultWorkdir();
+		startWithDefaultWorkdir();
 
-        JDialogOperator filterEditor = openFilterEditor(mainFrame);
+		JDialogOperator filterEditor = openFilterEditor(mainFrame);
 
-        selectFilter(filterEditor, 3);
+		selectFilter(filterEditor, 3);
 
-        getTextField(filterEditor, "Custom Label:").enterText("NewFilter");
+		getTextField(filterEditor, "Custom Label:").enterText("NewFilter");
 
-        new JMenuOperator(mainFrame, "View").pushMenu("View|Filter|NewFilter", "|");
+		new JMenuOperator(mainFrame, "View").pushMenu("View|Filter|NewFilter", "|");
 
-    }
+	}
 
 }

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter5.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter5.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ViewFilter;
+
+/**
+ *This test case verifies that Custom filter can be modified.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+
+public class ViewFilter5 extends ViewFilter {
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter5");
+    }
+
+    @Test
+    public void testViewFilter5()
+            throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+        startWithDefaultWorkdir();
+
+        JDialogOperator filterEditor = openFilterEditor(mainFrame);
+
+        selectFilter(filterEditor, 3);
+
+        getTextField(filterEditor, "Custom Label:").enterText("NewFilter");
+
+        new JMenuOperator(mainFrame, "View").pushMenu("View|Filter|NewFilter", "|");
+
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter5.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter5.java
@@ -35,27 +35,27 @@ import org.netbeans.jemmy.operators.JMenuOperator;
 
 public class ViewFilter5 extends ViewFilter {
 
-	public static void main(String[] args) {
-		JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter5");
-	}
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter5");
+    }
 
-	/**
-	 * This test case verifies that enabling test suite filter in the configure
-	 * filter will update the custom filter.
-	 */
-	@Test
-	public void testViewFilter5() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+    /**
+     * This test case verifies that enabling test suite filter in the configure
+     * filter will update the custom filter.
+     */
+    @Test
+    public void testViewFilter5() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
 
-		startWithDefaultWorkdir();
+        startWithDefaultWorkdir();
 
-		JDialogOperator filterEditor = openFilterEditor(mainFrame);
+        JDialogOperator filterEditor = openFilterEditor(mainFrame);
 
-		selectFilter(filterEditor, 3);
+        selectFilter(filterEditor, 3);
 
-		getTextField(filterEditor, "Custom Label:").enterText("NewFilter");
+        getTextField(filterEditor, "Custom Label:").enterText("NewFilter");
 
-		new JMenuOperator(mainFrame, "View").pushMenu("View|Filter|NewFilter", "|");
+        new JMenuOperator(mainFrame, "View").pushMenu("View|Filter|NewFilter", "|");
 
-	}
+    }
 
 }


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1.ReportCreate25.java
2.ReportCreate26.java
3.ReportCreate27.java
4.ReportCreate28.java
5.ReportCreate29.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903442](https://bugs.openjdk.org/browse/CODETOOLS-7903442): Feature Tests - Adding five JavaTest GUI legacy automated test scripts


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/jtharness pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/46.diff">https://git.openjdk.org/jtharness/pull/46.diff</a>

</details>
