### PR TITLE
7903444: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate25.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate25.java
@@ -1,0 +1,71 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate25 extends Test {
+    /**
+     * This test case verifies that Cancel button in the Create Report Directory
+     * will dismiss the dialog box .
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        createFakeRepDir(path);
+        addUsedFile(path);
+
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport htmlReport = new HtmlReport(rep);
+        htmlReport.setOptionsAll(false);
+        htmlReport.setOptionsResults(true);
+        htmlReport.setFilesAll(false);
+        htmlReport.setFilesPutInReport(true);
+
+        setPath(rep, path);
+        new JButtonOperator(rep, "Cancel").push();
+
+        if (new File(path + "html~1~").exists()) {
+            throw new JemmyException("backup directory was created");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate26.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate26.java
@@ -1,0 +1,80 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate26 extends Test {
+    /**
+     * This test case verifies that Cancel button in the Create Report Directory
+     * will not save settings in the preferences file.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        createFakeRepDir(path);
+        addUsedFile(path);
+
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport htmlReport = new HtmlReport(rep, false);
+
+        setPath(rep, path);
+        pressCreate(rep);
+        new JButtonOperator(findShowReportDialog(), "No").push();
+
+        rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        htmlReport = new HtmlReport(rep);
+        htmlReport.setExtraBackUp(false);
+
+        new JButtonOperator(rep, "Cancel").push();
+
+        rep = openReportCreation(mainFrame);
+        htmlReport = new HtmlReport(rep, true);
+
+        if (!htmlReport.isEBackUp()) {
+            throw new JemmyException("configuration was saved");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate27.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate27.java
@@ -1,0 +1,68 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate27 extends Test {
+    /**
+     * This test case verifies that selecting the plain text for last test run
+     * filter will create the report in the text format for the last test run
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, true);
+        setHtmlChecked(rep, false);
+        chooseFilter(rep, FiltersType.LAST_TEST_RUN);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+        File f = new File(path);
+        deleteDirectory(f);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(f);
+        findShowReportDialog();
+
+        File plainReport = new File(path + "text" + File.separator + "summary.txt");
+        if (!plainReport.canRead()) {
+            throw new JemmyException("can't read text file");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate28.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate28.java
@@ -1,0 +1,68 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate28 extends Test {
+    /**
+     * This test case verifies that selecting the plain text for the custom filter
+     * will create the report in the text format for the created custom filter.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, true);
+        setHtmlChecked(rep, false);
+        chooseFilter(rep, FiltersType.CUSTOM);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+        File f = new File(path);
+        deleteDirectory(f);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(f);
+        findShowReportDialog();
+
+        File plainReport = new File(path + "text" + File.separator + "summary.txt");
+        if (!plainReport.canRead()) {
+            throw new JemmyException("can't read text file");
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate29.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate29.java
@@ -1,0 +1,73 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class ReportCreate29 extends Test {
+    /**
+     * This test case verifies that selecting the custom filter in the report dialog
+     * could be modified and a report gets created.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, true);
+        setHtmlChecked(rep, false);
+        chooseFilter(rep, FiltersType.CUSTOM);
+        new JButtonOperator(rep, new NameComponentChooser("fconfig.config")).push();
+        JDialogOperator filter = new JDialogOperator(mainFrame, "Filter Editor");
+        new JButtonOperator(filter, "Cancel").push();
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+        File f = new File(path);
+        deleteDirectory(f);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(f);
+        findShowReportDialog();
+
+        File plainReport = new File(path + "text" + File.separator + "summary.txt");
+        if (!plainReport.canRead()) {
+            throw new JemmyException("can't read text file");
+        }
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1.ReportCreate25.java
2.ReportCreate26.java
3.ReportCreate27.java
4.ReportCreate28.java
5.ReportCreate29.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903444](https://bugs.openjdk.org/browse/CODETOOLS-7903444): Feature Tests - Adding five JavaTest GUI legacy automated test scripts


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/jtharness.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/47.diff">https://git.openjdk.org/jtharness/pull/47.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/47#issuecomment-1449667514)