### PR TITLE
7903466: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate19.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate19.java
@@ -1,0 +1,67 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate19 extends Test {
+    /**
+     * This test case verifies that selecting Not Run Test List box, Passed Test
+     * List and Failed Test List boxes will create norun.html , passed.html and
+     * failed.html files in the report directory.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport report = new HtmlReport(rep);
+        report.setFilesAll(false);
+        report.setFilesGenerateNotRunTests(true);
+        report.setFilesGeneratePassedTests(true);
+        report.setFilesGenerateFailedTests(true);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(path);
+        findShowReportDialog();
+
+        checkSpecifiedReportFiles(report, path);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate20.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate20.java
@@ -1,0 +1,64 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate20 extends Test {
+    /**
+     * This test case verifies that selecting Not Run Test List box, Passed Test
+     * List , Failed Test List and Error boxes will create norun.html , pass.html ,
+     * failed.html and error.html files in the report directory.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport report = new HtmlReport(rep);
+        report.setFilesAll(false);
+        report.setFilesGenerateFailedTests(true);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(path);
+        findShowReportDialog();
+
+        checkSpecifiedReportFiles(report, path);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate21.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate21.java
@@ -1,0 +1,64 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate21 extends Test {
+    /**
+     * This test case verifies that selecting the plain text for current
+     * configuration filter will create the report in the text format for the
+     * current configuration.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport report = new HtmlReport(rep);
+        report.setFilesAll(false);
+        report.setFilesGenerateErrorTests(true);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(path);
+        findShowReportDialog();
+
+        checkSpecifiedReportFiles(report, path);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate23.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate23.java
@@ -1,0 +1,64 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate23 extends Test {
+    /**
+     * This test case verifies that de-selecting the number for selecting the
+     * backups of old reports checkbox will not create any back up of the report.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport report = new HtmlReport(rep);
+        report.setFilesAll(false);
+        report.setFilesGenerateNotRunTests(true);
+        report.setFilesGeneratePassedTests(true);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(path);
+        findShowReportDialog();
+
+        checkSpecifiedReportFiles(report, path);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate24.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate24.java
@@ -1,0 +1,65 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate24 extends Test {
+    /**
+     * This test case verifies that selecting the number of times to backups will
+     * create one back up of the report.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setXmlChecked(rep, false);
+        setPlainChecked(rep, false);
+        HtmlReport report = new HtmlReport(rep);
+        report.setFilesAll(false);
+        report.setFilesGenerateNotRunTests(true);
+        report.setFilesGeneratePassedTests(true);
+        report.setFilesGenerateFailedTests(true);
+
+        final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        deleteDirectory(path);
+        setPath(rep, path);
+        pressCreate(rep);
+        addUsedFile(path);
+        findShowReportDialog();
+
+        checkSpecifiedReportFiles(report, path);
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.ReportCreate19.java
2.ReportCreate20.java
3.ReportCreate21.java
4.ReportCreate23.java
5.ReportCreate24.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903466](https://bugs.openjdk.org/browse/CODETOOLS-7903466): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jtharness.git pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/48.diff">https://git.openjdk.org/jtharness/pull/48.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/48#issuecomment-1537407918)