### PR TITLE
7903527: Improve accessibility in JT HTML reports - every HTML document should have `lang` attribute defined

### DIFF
--- a/src/com/sun/interview/WizPrint.java
+++ b/src/com/sun/interview/WizPrint.java
@@ -334,6 +334,7 @@ public class WizPrint {
             startTag(DOCTYPE);
             newLine();
             startTag(HTML);
+            writeAttr("lang", i18n.getString("wp.html.lang"));
             newLine();
             startTag(HEAD);
             writeTag(TITLE, interview.getTitle());

--- a/src/com/sun/interview/i18n.properties
+++ b/src/com/sun/interview/i18n.properties
@@ -84,6 +84,7 @@ wp.type.stringList=list of strings
 wp.type.tree=tree nodes
 wp.unset=(unset)
 wp.usage=Usage:\n  {0} [options] interview-class|wizard-file\nOptions:\n  -o output-file    Output file\n  -path             Write the questions on the current path\n  -all              Write all the questions in the interview\n
+wp.html.lang=en
 
 yn.yes=Yes
 yn.no=No

--- a/src/com/sun/javatest/InterviewPropagator.java
+++ b/src/com/sun/javatest/InterviewPropagator.java
@@ -617,6 +617,7 @@ public class InterviewPropagator {
             try {
                 HTMLWriterEx writer = new HTMLWriterEx(new PrintWriter(sw), i18n);
                 writer.startTag(HTMLWriterEx.HTML);
+                writer.writeLangAttr();
                 writer.startTag(HTMLWriterEx.HEAD);
                 writer.writeContentMeta();
                 writer.writeEntity(getCSS());

--- a/src/com/sun/javatest/audit/SummaryPane.java
+++ b/src/com/sun/javatest/audit/SummaryPane.java
@@ -89,6 +89,7 @@ class SummaryPane extends AuditPane {
 
     private void writeReport() throws IOException {
         out.startTag(HTMLWriterEx.HTML);
+        out.writeLangAttr();
         out.startTag(HTMLWriterEx.HEAD);
         out.writeContentMeta();
         //write("<title>" + ProductInfo.getName() + ": " + title + "</title>\n");

--- a/src/com/sun/javatest/exec/MultiFormatPane.java
+++ b/src/com/sun/javatest/exec/MultiFormatPane.java
@@ -335,6 +335,7 @@ public class MultiFormatPane extends JPanel implements Printable {
             HTMLWriterEx out = new HTMLWriterEx(sw, uif.getI18NResourceBundle());
 
             out.startTag(HTMLWriterEx.HTML);
+            out.writeLangAttr();
             out.startTag(HTMLWriterEx.HEAD);
             out.writeContentMeta();
             out.startTag(HTMLWriterEx.TITLE);

--- a/src/com/sun/javatest/exec/TP_OutputSubpanel.java
+++ b/src/com/sun/javatest/exec/TP_OutputSubpanel.java
@@ -206,6 +206,7 @@ class TP_OutputSubpanel extends TP_Subpanel {
         try {
             HTMLWriterEx out = new HTMLWriterEx(sw, uif.getI18NResourceBundle());
             out.startTag(HTMLWriterEx.HTML);
+            out.writeLangAttr();
             out.startTag(HTMLWriterEx.HEAD);
             out.writeContentMeta();
             out.endTag(HTMLWriterEx.HEAD);
@@ -226,6 +227,7 @@ class TP_OutputSubpanel extends TP_Subpanel {
         try {
             HTMLWriterEx out = new HTMLWriterEx(sw, uif.getI18NResourceBundle());
             out.startTag(HTMLWriterEx.HTML);
+            out.writeLangAttr();
             out.startTag(HTMLWriterEx.HEAD);
             out.writeContentMeta();
             out.endTag(HTMLWriterEx.HEAD);
@@ -368,6 +370,7 @@ class TP_OutputSubpanel extends TP_Subpanel {
         try {
             HTMLWriterEx out = new HTMLWriterEx(sw, uif.getI18NResourceBundle());
             out.startTag(HTMLWriterEx.HTML);
+            out.writeLangAttr();
             out.startTag(HTMLWriterEx.HEAD);
             out.writeContentMeta();
             out.endTag(HTMLWriterEx.HEAD);
@@ -450,6 +453,7 @@ class TP_OutputSubpanel extends TP_Subpanel {
         try {
             HTMLWriterEx out = new HTMLWriterEx(sw, uif.getI18NResourceBundle());
             out.startTag(HTMLWriterEx.HTML);
+            out.writeLangAttr();
             out.startTag(HTMLWriterEx.HEAD);
             out.writeContentMeta();
             out.endTag(HTMLWriterEx.HEAD);

--- a/src/com/sun/javatest/mrep/BrowserPane.java
+++ b/src/com/sun/javatest/mrep/BrowserPane.java
@@ -386,6 +386,7 @@ class BrowserPane extends JPanel {
             HTMLWriterEx out = new HTMLWriterEx(sw, uif.getI18NResourceBundle());
 
             out.startTag(HTMLWriterEx.HTML);
+            out.writeLangAttr();
             out.startTag(HTMLWriterEx.HEAD);
             out.writeContentMeta();
             out.startTag(HTMLWriterEx.TITLE);

--- a/src/com/sun/javatest/mrep/ReportTool.java
+++ b/src/com/sun/javatest/mrep/ReportTool.java
@@ -370,6 +370,7 @@ class ReportTool extends Tool {
             HTMLWriterEx out = new HTMLWriterEx(sw, uif.getI18NResourceBundle());
 
             out.startTag(HTMLWriterEx.HTML);
+            out.writeLangAttr();
             out.startTag(HTMLWriterEx.HEAD);
             out.writeContentMeta();
             out.startTag(HTMLWriterEx.TITLE);

--- a/src/com/sun/javatest/report/Report.java
+++ b/src/com/sun/javatest/report/Report.java
@@ -445,6 +445,7 @@ public class Report implements ReportModel {
             out.setI18NResourceBundle(i18n);
 
             out.startTag(HTMLWriterEx.HTML);
+            out.writeLangAttr();
             out.startTag(HTMLWriterEx.HEAD);
             out.writeContentMeta();
             out.startTag(HTMLWriterEx.TITLE);

--- a/src/com/sun/javatest/report/ReportWriter.java
+++ b/src/com/sun/javatest/report/ReportWriter.java
@@ -76,6 +76,7 @@ class ReportWriter extends HTMLWriterEx {
         this.i18n = i18n;
 
         startTag(HTMLWriterEx.HTML);
+        writeAttr("lang", i18n.getString("html.lang"));
         startTag(HTMLWriterEx.HEAD);
         writeContentMeta(cs);
         startTag(HTMLWriterEx.TITLE);

--- a/src/com/sun/javatest/report/i18n.properties
+++ b/src/com/sun/javatest/report/i18n.properties
@@ -215,3 +215,4 @@ stats.testResult.err=Report - bad initial tests in configuration settings, canno
 stats.title=Statistics
 stats.total=Total
 
+html.lang=en

--- a/src/com/sun/javatest/tool/Desktop.java
+++ b/src/com/sun/javatest/tool/Desktop.java
@@ -977,6 +977,7 @@ public class Desktop {
             try {
                 HTMLWriterEx out = new HTMLWriterEx(sw, uif.getI18NResourceBundle());
                 out.startTag(HTMLWriterEx.HTML);
+                out.writeLangAttr();
                 out.startTag(HTMLWriterEx.HEAD);
                 out.writeContentMeta();
                 out.endTag(HTMLWriterEx.HEAD);

--- a/src/com/sun/javatest/util/HTMLWriter.java
+++ b/src/com/sun/javatest/util/HTMLWriter.java
@@ -407,6 +407,16 @@ public class HTMLWriter {
     }
 
     /**
+     * Writes value of 'lang' attribute that is defined in resource bundle.
+     * This method is expected to be called after opening (starting) the root HTML tag.
+     *
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void writeLangAttr() throws IOException {
+        writeAttr("lang", i18n.getString("html.lang"));
+    }
+
+    /**
      * Write an attribute for a tag. A tag must previously have been started.
      * All tag attributes must be written before any body text is written.
      * The value will be quoted if necessary when writing it to the underlying

--- a/src/com/sun/javatest/util/i18n.properties
+++ b/src/com/sun/javatest/util/i18n.properties
@@ -30,3 +30,4 @@ lineParser.ioError={0,choice,0|line {2},1|{1}:{2}}: IO error: {3}
 lineParser.unterminatedString={0,choice,0|line {2},1|{1}:{2}}: unterminated string
 log.error=Error accessing log file "{0}": {1}
 sysEnv.err=Error accessing system environment values: {0}
+html.lang=en


### PR DESCRIPTION
Currently the generated HTML reports/configs etc. have <html> tag without `lang` attr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903527](https://bugs.openjdk.org/browse/CODETOOLS-7903527): Improve accessibility in JT HTML reports - every HTML document should have `lang` attribute defined (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/jtharness.git pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/50.diff">https://git.openjdk.org/jtharness/pull/50.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/50#issuecomment-1682215589)