### PR TITLE
7903543: Making Agent's connections more NIO friendly

### DIFF
--- a/src/com/sun/javatest/agent/ActiveConnectionFactory.java
+++ b/src/com/sun/javatest/agent/ActiveConnectionFactory.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,9 @@
 package com.sun.javatest.agent;
 
 import java.io.IOException;
-import java.net.Socket;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.nio.channels.SocketChannel;
 
 /**
  * A factory for creating connections to be used by agents running in "active" mode.
@@ -80,7 +81,8 @@ public class ActiveConnectionFactory implements ConnectionFactory {
     @Override
     public Connection nextConnection() throws ConnectionFactory.Fault {
         try {
-            return new SocketConnection(new Socket(host, port));
+            return new SocketConnection(
+                    SocketChannel.open(new InetSocketAddress(host, port)));
         } catch (UnknownHostException e) {
             throw new ConnectionFactory.Fault(e, true);
         } catch (IOException e) {

--- a/src/com/sun/javatest/agent/InterruptableSocketConnection.java
+++ b/src/com/sun/javatest/agent/InterruptableSocketConnection.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2008, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,11 +30,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.net.Socket;
+import java.nio.channels.SocketChannel;
 
 public class InterruptableSocketConnection extends SocketConnection {
 
     public InterruptableSocketConnection(Socket socket) throws IOException {
         super(socket);
+    }
+
+    public InterruptableSocketConnection(SocketChannel socketChannel) throws IOException {
+        super(socketChannel);
     }
 
     public InterruptableSocketConnection(String host, int port) throws IOException {

--- a/src/com/sun/javatest/agent/PassiveConnectionFactory.java
+++ b/src/com/sun/javatest/agent/PassiveConnectionFactory.java
@@ -74,8 +74,8 @@ public class PassiveConnectionFactory implements ConnectionFactory {
      * Create a factory for creating connections to be used by agents running
      * in "passive" mode.
      *
-     * @param serverSocketChannel The server socket used to accept incoming
-     *                     connection requests.
+     * @param serverSocketChannel The server socket channel used to accept incoming
+     *                            connection requests.
      */
     public PassiveConnectionFactory(ServerSocketChannel serverSocketChannel) {
         this.serverSocketChannel = Optional.of(serverSocketChannel);

--- a/src/com/sun/javatest/agent/SocketConnection.java
+++ b/src/com/sun/javatest/agent/SocketConnection.java
@@ -40,6 +40,7 @@ import java.nio.channels.SocketChannel;
 import java.net.Socket;
 import java.net.StandardSocketOptions;
 import java.util.Hashtable;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -77,7 +78,7 @@ public class SocketConnection implements Connection {
     /**
      * Create a connection via a TCP/IP socketChannel.
      *
-     * @param socketChannel The socketChannel to use for the connection.
+     * @param socketChannel The socket сhannel to use for the connection.
      * @throws NullPointerException if socketChannel is null
      */
     public SocketConnection(SocketChannel socketChannel) {
@@ -141,11 +142,11 @@ public class SocketConnection implements Connection {
     }
 
     /**
-     * Creates a ServerSocket instance in the environment where reading
+     * Creates a ServerSocketChannel instance in the environment where reading
      * of system properties is allowed.
      *
      * @param port - port to bind
-     * @return new created ServerSocket
+     * @return new created ServerSocketChannel
      * @throws java.io.IOException - if ServerSocket is not created
      */
     public static ServerSocketChannel createServerSocketChannel(int port) throws IOException {
@@ -153,12 +154,12 @@ public class SocketConnection implements Connection {
     }
 
     /**
-     * Creates a ServerSocket instance in the environment where reading
+     * Creates a ServerSocketChannel instance in the environment where reading
      * of system properties is allowed.
      *
      * @param port    - port to bind
      * @param backlog - backlog
-     * @return new created ServerSocket
+     * @return new created ServerSocketChannel
      * @throws java.io.IOException - if ServerSocket is not created
      */
     public static synchronized ServerSocketChannel createServerSocketChannel(int port, int backlog)

--- a/src/com/sun/javatest/agent/SocketConnection.java
+++ b/src/com/sun/javatest/agent/SocketConnection.java
@@ -78,7 +78,7 @@ public class SocketConnection implements Connection {
     /**
      * Create a connection via a TCP/IP socketChannel.
      *
-     * @param socketChannel The socket сhannel to use for the connection.
+     * @param socketChannel The socket channel to use for the connection.
      * @throws NullPointerException if socketChannel is null
      */
     public SocketConnection(SocketChannel socketChannel) {

--- a/src/com/sun/javatest/httpd/RequestHandler.java
+++ b/src/com/sun/javatest/httpd/RequestHandler.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 1996, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ import java.io.LineNumberReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -51,7 +53,7 @@ class RequestHandler implements Runnable {
     private static final String HTTP_CONTENT_HTML = HTTP_CONTENT_TYPE + "text/html";
     protected static boolean debug = Boolean.getBoolean("debug." + RequestHandler.class.getName());
     private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(RequestHandler.class);
-    private Socket soc;
+    private SocketChannel socketChannel;
     private PrintWriter out;
     private LineNumberReader in;
     /**
@@ -60,8 +62,8 @@ class RequestHandler implements Runnable {
      * notified.  For special URLs, this class will delegate responsibility to
      * them.
      */
-    public RequestHandler(Socket soc) {
-        this.soc = soc;
+    public RequestHandler(SocketChannel socketChannel) {
+        this.socketChannel = socketChannel;
     }
 
     @Override
@@ -73,16 +75,16 @@ class RequestHandler implements Runnable {
             if (debug) {
                 StringBuilder buf = new StringBuilder();
                 buf.append("Handling request from ");
-                buf.append(soc.getInetAddress().getHostName());
+                buf.append(socketChannel.socket().getInetAddress().getHostName());
                 buf.append(" (");
-                buf.append(soc.getInetAddress().getHostAddress());
+                buf.append(socketChannel.socket().getInetAddress().getHostAddress());
                 buf.append(")");
                 System.out.println(buf.toString());
                 buf.setLength(0);
             }
 
-            out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(soc.getOutputStream(), StandardCharsets.UTF_8)));
-            in = new LineNumberReader(new InputStreamReader(soc.getInputStream(), StandardCharsets.UTF_8));
+            out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(Channels.newOutputStream(socketChannel), StandardCharsets.UTF_8)));
+            in = new LineNumberReader(new InputStreamReader(Channels.newInputStream(socketChannel), StandardCharsets.UTF_8));
 
 
             request = in.readLine();

--- a/unit-tests/com/sun/javatest/agent/RemoteTestChannel.java
+++ b/unit-tests/com/sun/javatest/agent/RemoteTestChannel.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,6 @@ public class RemoteTestChannel {
 
         try {
             ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
-            serverSocketChannel.socket().setReuseAddress(true);
             serverSocketChannel.bind(new InetSocketAddress(port));
 
             if (port == 0)

--- a/unit-tests/com/sun/javatest/agent/RemoteTestChannel.java
+++ b/unit-tests/com/sun/javatest/agent/RemoteTestChannel.java
@@ -1,0 +1,328 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javatest.agent;
+
+import com.sun.javatest.Status;
+import com.sun.javatest.Test;
+import org.junit.Assert;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.util.Vector;
+
+public class RemoteTestChannel {
+
+
+    @org.junit.Test
+    public void test() {
+        RemoteTestChannel t = new RemoteTestChannel();
+        boolean ok = t.run(System.out);
+        Assert.assertTrue(ok);
+    }
+
+    public boolean run(PrintStream log) {
+        String host = "localhost";
+        int port = 0;
+        int seed = 0;
+
+        try {
+            ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+            serverSocketChannel.socket().setReuseAddress(true);
+            serverSocketChannel.bind(new InetSocketAddress(port));
+
+            if (port == 0)
+                port = serverSocketChannel.socket().getLocalPort();
+            ConnectionFactory cf = new PassiveConnectionFactory(serverSocketChannel);
+            Agent agent = new Agent(cf, 1);
+            Thread t = new Thread(agent);
+            t.setName("Test Agent");
+            t.start();
+            log.println("Test Agent started");
+
+            Random rgen = new Random(seed);
+            int nTestsOK = 0;
+
+            for (int i = 0; i < nTests; i++) {
+                Parent p = new Parent(host, port, Child.class.getName(), rgen.nextInt(), log);
+                Status s = p.run();
+                if (s.getType() == Status.PASSED)
+                    nTestsOK++;
+            }
+
+            if (nTestsOK == nTests) {
+                log.println("all tests succeeded");
+                return true;
+            } else {
+                log.println((nTests - nTestsOK) + " tests failed out of " + nTests);
+                return false;
+            }
+        } catch (IOException e) {
+            e.printStackTrace(log);
+            log.println("Unexpected exception: " + e);
+            return false;
+        }
+    }
+
+    private int nTests = 10;
+    static final int MAX_LINES_PER_TEST = 128;
+    static final int MAX_CHARS_PER_LINE = 128;
+
+    static class Parent {
+        Parent(String host, int port, String testClassName, int seed, PrintStream log) {
+            this.port = port;
+            this.testClassName = testClassName;
+            this.seed = seed;
+            this.log = log;
+            //System.err.println("Parent: seed=" + seed);
+        }
+
+        Status run() {
+            try {
+                ThreadSet ts = new ThreadSet();
+
+                AgentManager.Task agentTask = AgentManager.access().connectToPassiveAgent("localhost", port);
+
+                PipedWriter testLog = new PipedWriter();
+                PipedWriter testRef = new PipedWriter();
+
+                Random rgen = new Random(seed);
+
+                // the sequence of the next few rgen calls must be the same for the
+                // both the parent and the child
+                RandomReader logReader = new RandomReader(rgen.nextInt(), new PipedReader(testLog), ts);
+                RandomReader refReader = new RandomReader(rgen.nextInt(), new PipedReader(testRef), ts);
+                Status exp = rgen.nextStatus();
+
+                ts.start();
+
+                String[] args = {Integer.toString(seed)};
+                Status rcv = agentTask.executeTest("TEST", testClassName, args, false,
+                        new PrintWriter(testLog), new PrintWriter(testRef));
+
+                // close the output streams, to flush data through the pipes to the readers
+                testLog.close();
+                testRef.close();
+
+                // wait for the readers to complete
+                ts.join();
+
+                boolean refOK = refReader.ok();
+                boolean logOK = logReader.ok();
+                boolean statusOK = equal(exp, rcv);
+                if (refOK && logOK && statusOK)
+                    return Status.passed("test passed");
+                else {
+                    if (!refOK)
+                        log.println("Reference stream check failed");
+                    if (!logOK)
+                        log.println("Log stream check failed");
+                    if (!statusOK) {
+                        log.println("Status check failed");
+                        log.println("Status returned from test: " + rcv);
+                    }
+                    return Status.failed("test failed");
+                }
+            } catch (InterruptedException | IOException e) {
+                e.printStackTrace(log);
+                log.println("Unexpected exception: " + e);
+                return Status.failed("Unexpected exception: " + e.getClass().getName());
+            }
+        }
+
+        private boolean equal(Status s1, Status s2) {
+            return s1.getType() == s2.getType() && s1.getReason().equals(s2.getReason());
+        }
+
+        int port;
+        String testClassName;
+        int seed;
+        PrintStream log;
+    }
+
+    public static class Child implements Test {
+        public Status run(String[] args, PrintWriter log, PrintWriter ref) {
+            if (args.length != 1)
+                return Status.failed("no seed specified for child");
+
+            int seed = Integer.parseInt(args[0], 10);
+            //System.err.println("Child: seed=" + seed);
+
+            try {
+                Random rgen = new Random(seed);
+                ThreadSet t = new ThreadSet();
+
+                // the sequence of the next few rgen calls must be the same for the
+                // both the parent and the child
+                RandomWriter logWriter = new RandomWriter(rgen.nextInt(), log, t);
+                RandomWriter refWriter = new RandomWriter(rgen.nextInt(), ref, t);
+                Status s = rgen.nextStatus();
+
+                t.start();
+                t.join();
+
+                return s;
+            } catch (InterruptedException e) {
+                return Status.failed("Unexpected exception: " + e.getClass().getName());
+            }
+        }
+
+    }
+
+    private static class RandomReader extends Thread {
+        RandomReader(int seed, Reader in, ThreadSet t) {
+            this.seed = seed;
+            this.in = new BufferedReader(in);
+            this.t = t;
+            t.add(this);
+        }
+
+        public void run() {
+            try {
+                Random rgen = new Random(seed);
+                int expectCount = rgen.nextInt(RemoteTestChannel.MAX_LINES_PER_TEST);
+                int foundCount = 0;
+                String line;
+                try {
+                    while ((line = in.readLine()) != null) {
+                        String expectLine = rgen.nextString();
+                        if (!line.equals(expectLine)) {
+                            System.out.println("EXPECT: " + expectLine);
+                            System.out.println("FOUND:  " + line);
+                            errors++;
+                        }
+                        foundCount++;
+                    }
+                } catch (IOException e) {
+                    System.out.println("Unexpected exception: " + e);
+                    errors++;
+                }
+                if (expectCount != foundCount) {
+                    System.out.println("expect " + expectCount + "; found " + foundCount);
+                    errors++;
+                }
+            } finally {
+                t.notifyExiting();
+            }
+        }
+
+        synchronized boolean ok() {
+            return errors == 0;
+        }
+
+        private int seed;
+        private BufferedReader in;
+        private ThreadSet t;
+        private int errors;
+    }
+
+    private static class RandomWriter extends Thread {
+        RandomWriter(int seed, PrintWriter out, ThreadSet t) {
+            this.seed = seed;
+            this.out = out;
+            this.t = t;
+            t.add(this);
+        }
+
+        public void run() {
+            try {
+                Random rgen = new Random(seed);
+                int n = rgen.nextInt(RemoteTestChannel.MAX_LINES_PER_TEST);
+                for (int i = 0; i < n; i++) {
+                    String s = rgen.nextString();
+                    out.println(s);
+                }
+                out.flush();
+            } finally {
+                t.notifyExiting();
+            }
+        }
+
+        synchronized boolean ok() {
+            return errors == 0;
+        }
+
+        private int seed;
+        private PrintWriter out;
+        private ThreadSet t;
+        private int errors;
+    }
+
+    private static class ThreadSet {
+        public synchronized void add(Thread t) {
+            threads.addElement(t);
+        }
+
+        public synchronized void start() {
+            for (int i = 0; i < threads.size(); i++)
+                threads.elementAt(i).start();
+        }
+
+        public synchronized void join() throws InterruptedException {
+            while (threads.size() > 0)
+                wait();
+        }
+
+        public synchronized void notifyExiting() {
+            threads.removeElement(Thread.currentThread());
+            notifyAll();
+        }
+
+        private Vector<Thread> threads = new Vector<>();
+    }
+
+    private static class Random extends java.util.Random {
+
+        static final long serialVersionUID = 0L;
+
+        Random(int seed) {
+            super(seed);
+        }
+
+        public int nextInt(int upb) {
+            return Math.abs(nextInt()) % upb;
+        }
+
+        private int privateNextInt(int lwb, int upb) {
+            return lwb + Math.abs(nextInt()) % (upb - lwb);
+        }
+
+        String nextString() {
+            int l = nextInt(MAX_CHARS_PER_LINE);
+            StringBuffer sb = new StringBuffer(l);
+            for (int i = 0; i < l; i++) {
+                sb.append((char) privateNextInt(32, 128)); // cheat!!
+            }
+            return new String(sb);
+
+        }
+
+        Status nextStatus() {
+            return Status.passed("");
+        }
+    }
+}


### PR DESCRIPTION
This is for refactoring few JT agent's helper classes to support and work with SocketChannels

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903543](https://bugs.openjdk.org/browse/CODETOOLS-7903543): Making Agent's connections more NIO friendly (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/jtharness.git pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/51.diff">https://git.openjdk.org/jtharness/pull/51.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/51#issuecomment-1699433670)