### PR TITLE
7903564: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate30.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate30.java
@@ -1,0 +1,72 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+/**
+ * This test case verifies that Cancel button in the Create Report Directory
+ * will dismiss the dialog box .
+ */
+
+public class ReportCreate30 extends Test {
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+          deleteDirectory(path);
+          createFakeRepDir(path);
+          addUsedFile(path);
+
+          startJavaTestWithDefaultWorkDirectory();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          setXmlChecked(rep, false);
+          setPlainChecked(rep, false);
+          HtmlReport htmlReport = new HtmlReport(rep);
+          htmlReport.setOptionsAll(false);
+          htmlReport.setOptionsResults(true);
+          htmlReport.setFilesAll(false);
+          htmlReport.setFilesPutInReport(true);
+
+          setPath(rep, path);
+          new JButtonOperator(rep, "Cancel").push();
+
+          if (new File(path + "html~1~").exists()) {
+               throw new JemmyException("backup directory was created");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate31.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate31.java
@@ -1,0 +1,80 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+/**
+ * This test case verifies that Cancel button in the Create Report Directory
+ * will not save settings in the preferences file.
+ */
+public class ReportCreate31 extends Test {
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+          deleteDirectory(path);
+          createFakeRepDir(path);
+          addUsedFile(path);
+
+          startJavaTestWithDefaultWorkDirectory();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          setXmlChecked(rep, false);
+          setPlainChecked(rep, false);
+          HtmlReport htmlReport = new HtmlReport(rep, false);
+
+          setPath(rep, path);
+          pressCreate(rep);
+          new JButtonOperator(findShowReportDialog(), "No").push();
+
+          rep = openReportCreation(mainFrame);
+
+          setXmlChecked(rep, false);
+          setPlainChecked(rep, false);
+          htmlReport = new HtmlReport(rep);
+          htmlReport.setExtraBackUp(false);
+
+          new JButtonOperator(rep, "Cancel").push();
+
+          rep = openReportCreation(mainFrame);
+          htmlReport = new HtmlReport(rep, true);
+
+          if (!htmlReport.isEBackUp()) {
+               throw new JemmyException("configuration was saved");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate32.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate32.java
@@ -1,0 +1,69 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+/**
+ * This test case verifies that selecting the plain text for last test run
+ * filter will create the report in the text format for the last test run.
+ */
+
+public class ReportCreate32 extends Test {
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          startJavaTestWithDefaultWorkDirectory();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          setXmlChecked(rep, false);
+          setPlainChecked(rep, true);
+          setHtmlChecked(rep, false);
+          chooseFilter(rep, FiltersType.LAST_TEST_RUN);
+
+          final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+          File f = new File(path);
+          deleteDirectory(f);
+          setPath(rep, path);
+          pressCreate(rep);
+          addUsedFile(f);
+          findShowReportDialog();
+
+          File plainReport = new File(path + "text" + File.separator + "summary.txt");
+          if (!plainReport.canRead()) {
+               throw new JemmyException("can't read text file");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate33.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate33.java
@@ -1,0 +1,68 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+/**
+ * This test case verifies that selecting the plain text for the custom filter
+ * will create the report in the text format for the created custom filter.
+ */
+public class ReportCreate33 extends Test {
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          startJavaTestWithDefaultWorkDirectory();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          setXmlChecked(rep, false);
+          setPlainChecked(rep, true);
+          setHtmlChecked(rep, false);
+          chooseFilter(rep, FiltersType.CUSTOM);
+
+          final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+          File f = new File(path);
+          deleteDirectory(f);
+          setPath(rep, path);
+          pressCreate(rep);
+          addUsedFile(f);
+          findShowReportDialog();
+
+          File plainReport = new File(path + "text" + File.separator + "summary.txt");
+          if (!plainReport.canRead()) {
+               throw new JemmyException("can't read text file");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate34.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate34.java
@@ -1,0 +1,74 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import static jthtest.ReportCreate.ReportCreate.*;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+/**
+ * This test case verifies that selecting the custom filter in the report dialog
+ * could be modified and a report gets created.
+ */
+
+public class ReportCreate34 extends Test {
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          startJavaTestWithDefaultWorkDirectory();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          setXmlChecked(rep, false);
+          setPlainChecked(rep, true);
+          setHtmlChecked(rep, false);
+          chooseFilter(rep, FiltersType.CUSTOM);
+          new JButtonOperator(rep, new NameComponentChooser("fconfig.config")).push();
+          JDialogOperator filter = new JDialogOperator(mainFrame, "Filter Editor");
+          new JButtonOperator(filter, "Cancel").push();
+
+          final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_PLAIN + File.separator;
+          File f = new File(path);
+          deleteDirectory(f);
+          setPath(rep, path);
+          pressCreate(rep);
+          addUsedFile(f);
+          findShowReportDialog();
+
+          File plainReport = new File(path + "text" + File.separator + "summary.txt");
+          if (!plainReport.canRead()) {
+               throw new JemmyException("can't read text file");
+          }
+     }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.ReportCreate30.java
2.ReportCreate31.java
3.ReportCreate32.java
4.ReportCreate33.java
5.ReportCreate34.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903564](https://bugs.openjdk.org/browse/CODETOOLS-7903564): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/jtharness.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/53.diff">https://git.openjdk.org/jtharness/pull/53.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/53#issuecomment-1739962384)