### PR TITLE
7903566: Feature Tests - Adding four JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate11.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate11.java
@@ -1,0 +1,85 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+/**
+ * This test case verifies that selecting the Test Environment box will display a link to the current configuration for the test in the report.html.
+ */
+
+import jthtest.ViewFilter.ViewFilter;
+import java.io.File;
+import jthtest.Test;
+import static jthtest.ReportCreate.ReportCreate.*;
+import org.netbeans.jemmy.operators.JCheckBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate11 extends Test {
+
+     JFrameOperator mainFrame;
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          startJavaTestWithDefaultWorkDirectory();
+
+          mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+          File f = new File(path);
+          deleteDirectory(f);
+          setPath(rep, path);
+
+          setPlainChecked(rep, false);
+          setXmlChecked(rep, false);
+          HtmlReport html = new HtmlReport(rep);
+          html.setOptionsAll(false);
+          html.setOptionsConfiguration(true, false, true, false);
+          html.setFilesAll(false);
+          html.setFilesPutInReport(true);
+
+          pressCreate(rep);
+          addUsedFile(f);
+
+          pressYes(findShowReportDialog());
+
+          new HtmlReportChecker(path, html).commitMainCheck();
+     }
+
+     public void selectEnableTSFilter() {
+          JDialogOperator filterEditor = ViewFilter.openFilterEditor(mainFrame);
+
+          ViewFilter.selectFilter(filterEditor, 4);
+
+          ViewFilter.chooseTab(filterEditor, "Special");
+
+          new JCheckBoxOperator(filterEditor, "Enable test suite filter.").setSelected(true);
+
+          ViewFilter.ok(filterEditor);
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate12.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate12.java
@@ -1,0 +1,70 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import jthtest.Test;
+import static jthtest.ReportCreate.ReportCreate.*;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+/**
+ * This test case verifies that selecting the Standard Values box will display a
+ * link to the current configuration for the test in the report.html.
+ */
+public class ReportCreate12 extends Test {
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          startJavaTestWithDefaultWorkDirectory();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+          File f = new File(path);
+          deleteDirectory(f);
+          setPath(rep, path);
+
+          setXmlChecked(rep, false);
+          setPlainChecked(rep, false);
+          HtmlReport html = new HtmlReport(rep);
+          html.setFilesAll(false);
+          html.setFilesPutInReport(true);
+          html.setOptionsAll(false);
+          html.setOptionsConfiguration(true, false, false, true);
+
+          pressCreate(rep);
+          addUsedFile(f);
+
+          pressYes(findShowReportDialog());
+
+          HtmlReportChecker check = new HtmlReportChecker(path, html);
+          check.commitMainCheck();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate13.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate13.java
@@ -1,0 +1,67 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import jthtest.Test;
+import static jthtest.ReportCreate.ReportCreate.*;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+/**
+ * This test case verifies that selecting the keyword Summary box will display
+ * the keywords used by the testsuite for the test run in the report.html.
+ */
+public class ReportCreate13 extends Test {
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          startJavaTestWithDefaultWorkDirectory();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          setXmlChecked(rep, false);
+          setPlainChecked(rep, false);
+          HtmlReport html = new HtmlReport(rep);
+          html.setOptionsAll(false);
+          html.setOptionsKeyword(true);
+          html.setFilesAll(false);
+          html.setFilesPutInReport(true);
+
+          final String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+          setPath(rep, path);
+          File f = new File(path);
+          deleteDirectory(f);
+          pressCreate(rep);
+          addUsedFile(f);
+          pressYes(findShowReportDialog());
+
+          new HtmlReportChecker(path, html).commitMainCheck();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate8.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate8.java
@@ -1,0 +1,70 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+/**
+ * This test case verifies that selecting the Question Log box will display a link to the configuration for the test suite in the report.html .
+ */
+
+import java.io.File;
+import jthtest.Test;
+import static jthtest.ReportCreate.ReportCreate.*;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate8 extends Test {
+
+     public void testImpl() throws Exception {
+          deleteUserData();
+          startJavaTestWithDefaultWorkDirectory();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          JDialogOperator rep = openReportCreation(mainFrame);
+
+          setPlainChecked(rep, false);
+          setXmlChecked(rep, false);
+          String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+          File f = new File(path);
+          deleteDirectory(f);
+
+          setPath(rep, path);
+
+          HtmlReport html = new HtmlReport(rep);
+          html.setFilesAll(false);
+          html.setFilesPutInReport(true);
+          html.setOptionsAll(false);
+          html.setOptionsConfiguration(true, true, false, false);
+
+          pressCreate(rep);
+          addUsedFile(f);
+
+          pressYes(findShowReportDialog());
+
+          new HtmlReportChecker(path, html).commitMainCheck();
+     }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine.

1.ReportCreate8.java
2.ReportCreate11.java
3.ReportCreate12.java
4.ReportCreate13.java

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903566](https://bugs.openjdk.org/browse/CODETOOLS-7903566): Feature Tests - Adding four JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jtharness.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/54.diff">https://git.openjdk.org/jtharness/pull/54.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/54#issuecomment-1741193227)