### PR TITLE
Use ThreadGroup for passive connection

### DIFF
--- a/src/com/sun/javatest/agent/InterruptableSocketConnection.java
+++ b/src/com/sun/javatest/agent/InterruptableSocketConnection.java
@@ -39,11 +39,11 @@ public class InterruptableSocketConnection extends SocketConnection {
     private ThreadGroup ioThreadGroup;
 
     public InterruptableSocketConnection(Socket socket) throws IOException {
-        this(Thread.currentThread().getThreadGroup(), socket);
+        this(null, socket);
     }
 
     public InterruptableSocketConnection(String host, int port) throws IOException {
-        this(Thread.currentThread().getThreadGroup(), host, port);
+        this(null, host, port);
     }
 
     public InterruptableSocketConnection(ThreadGroup ioThreadGroup, Socket socket) throws IOException {

--- a/src/com/sun/javatest/agent/PassiveConnectionFactory.java
+++ b/src/com/sun/javatest/agent/PassiveConnectionFactory.java
@@ -35,10 +35,20 @@ import java.net.ServerSocket;
 public class PassiveConnectionFactory implements ConnectionFactory {
     private ServerSocket serverSocket;
 
+    private static ThreadGroup getRootThreadGroup()
+    {
+        ThreadGroup root = Thread.currentThread().getThreadGroup();
+        while (root.getParent() != null) {
+            root = root.getParent();
+        }
+        return root;
+    }
+
+
     /**
      * The {@link ThreadGroup} used for reading during class loading.
      */
-    private ThreadGroup ioThreadGroup = new ThreadGroup("Passive Class Loading IO");
+    private ThreadGroup ioThreadGroup = new ThreadGroup(getRootThreadGroup(), "Passive Class Loading IO");
 
     /**
      * Create a factory for creating connections to be used by agents running

--- a/src/com/sun/javatest/agent/PassiveConnectionFactory.java
+++ b/src/com/sun/javatest/agent/PassiveConnectionFactory.java
@@ -36,6 +36,11 @@ public class PassiveConnectionFactory implements ConnectionFactory {
     private ServerSocket serverSocket;
 
     /**
+     * The {@link ThreadGroup} used for reading during class loading.
+     */
+    private ThreadGroup ioThreadGroup = new ThreadGroup("Passive Class Loading IO");
+
+    /**
      * Create a factory for creating connections to be used by agents running
      * in "passive" mode.
      *
@@ -79,7 +84,7 @@ public class PassiveConnectionFactory implements ConnectionFactory {
     public Connection nextConnection() throws ConnectionFactory.Fault {
         try {
 //          return new SocketConnection(serverSocket.accept());
-            return new InterruptableSocketConnection(serverSocket.accept());
+            return new InterruptableSocketConnection(ioThreadGroup, serverSocket.accept());
         } catch (IOException e) {
             throw new ConnectionFactory.Fault(e, false);
         }


### PR DESCRIPTION
Passive connections use a separate thread to ensure interruptible IO. Since this is technically part of the test setup it should use a separate ThreadGroup.

Please let me know if anything else is needed or you want to see any changes. I was trying to follow your processes but found a lot of dead links.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jtharness.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/58.diff">https://git.openjdk.org/jtharness/pull/58.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/58#issuecomment-1909135721)