### PR TITLE
exracting method to fill in result status to allow for overriding in implementations of Script

### DIFF
--- a/src/com/sun/javatest/Script.java
+++ b/src/com/sun/javatest/Script.java
@@ -466,7 +466,7 @@ public abstract class Script {
         testResult.setEnvironment(env);
         testResult.putProperty("totalTime", Long.toString(System.currentTimeMillis() - startMs));
         //allows for potential aditional status modification in Script subclasses
-        fillTestExecutionStatus(testResult, execStatus);
+        setTestResultStatus(testResult, execStatus);
 
         try {
             if (execStatus.getType() != Status.PASSED || jtrIfPassed) {
@@ -484,7 +484,7 @@ public abstract class Script {
      * @param testResultToFill TestResult object to be filled with Status
      * @param execStatus Status object to fill into the testResultToFill
      */
-    protected void fillTestExecutionStatus(TestResult testResultToFill, Status execStatus) {
+    protected void setTestResultStatus(TestResult testResultToFill, Status execStatus) {
         testResultToFill.setStatus(execStatus);
     }
 

--- a/src/com/sun/javatest/Script.java
+++ b/src/com/sun/javatest/Script.java
@@ -465,7 +465,8 @@ public abstract class Script {
 
         testResult.setEnvironment(env);
         testResult.putProperty("totalTime", Long.toString(System.currentTimeMillis() - startMs));
-        testResult.setStatus(execStatus);
+        //allows for potential aditional status modification in Script subclasses
+        fillTestExecutionStatus(testResult, execStatus);
 
         try {
             if (execStatus.getType() != Status.PASSED || jtrIfPassed) {
@@ -475,6 +476,16 @@ public abstract class Script {
             // ignore it; the test will have an error status already
             //throw new JavaTestError("Unable to write result file! " + e);
         }
+    }
+
+    /**
+     * Following method allows for overriding in the subclasses of Script class, ultimately allowing
+     * implementations of custom treatment in specific cases without reimplementing the whole run method.
+     * @param testResultToFill TestResult object to be filled with Status
+     * @param execStatus Status object to fill into the testResultToFill
+     */
+    protected void fillTestExecutionStatus(TestResult testResultToFill, Status execStatus) {
+        testResultToFill.setStatus(execStatus);
     }
 
     /**


### PR DESCRIPTION
This is an alternative approach to https://github.com/openjdk/jtharness/pull/57
counting on Script subclasses that will allow for such modifications.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.org/jtharness.git pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/59.diff">https://git.openjdk.org/jtharness/pull/59.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/59#issuecomment-1883770671)