### PR TITLE
7903700: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load7.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load7.java
@@ -1,0 +1,65 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_Load;
+
+import jthtest.ConfigTools;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class Config_Load7 extends Test {
+
+    public void testImpl() throws Exception {
+     JTFrame mainFrame = new JTFrame(true);
+
+     mainFrame.openDefaultTestSuite();
+     addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+     Configuration configuration = mainFrame.getConfiguration();
+     configuration.load(ConfigTools.CONFIG_NAME, true);
+
+     ConfigDialog config = configuration.openByKey();
+     config.load(ConfigTools.SECOND_CONFIG_NAME, true);
+
+     verifyOpeningNewConfigFile(config);
+    }
+
+    private boolean verifyOpeningNewConfigFile(ConfigDialog config) {
+     JListOperator list = new JListOperator(config.getConfigDialog());
+     list.selectItem(1);
+     return new JTextFieldOperator(config.getConfigDialog(), new NameComponentChooser("str.txt")).getText().equals(ConfigTools.SECOND_CONFIG_NAME);
+    }
+
+    @Override
+    public String getDescription() {
+     return "Load a configuration, open Configuration Editor. Load another configuration from it. Configuration Editor internals should be repainted";
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree1.java
+++ b/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree1.java
@@ -1,0 +1,124 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_TestTree;
+
+import com.sun.interview.wizard.selectiontree.SelectionTree;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_TestTree1 extends Test {
+     /**
+      * This test case verifies that selecting number of tests during execution will
+      * not change from what was selected.
+      */
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          Configuration conf = mainFrame.getConfiguration();
+          conf.load(CONFIG_NAME, true);
+
+          ConfigDialog cd = conf.openByMenu(true);
+          ConfigDialog.QuestionTree tree = cd.getQuestionTree();
+
+          int initRowCount = tree.getRowCount();
+          SelectionTree stree = tree.getTree();
+          int initSelected = stree.getSelection().length;
+          if (initRowCount != 4) {
+               errors.add("Initially there are not 3 visible rows in the tree");
+          }
+          if (initSelected != 1) {
+               errors.add("Initially there are " + initSelected + " selected rows in the tree while 1 (root) expected");
+          }
+
+          tree.clickOnRow(0);
+          if (stree.getSelectionRows()[0] != 0) {
+               errors.add(stree.getSelectionRows()[0] + " row is selected while expected 0");
+          }
+          tree.clickOnRow(1);
+          if (stree.getSelectionRows()[0] != 1) {
+               errors.add(stree.getSelectionRows()[0] + " row is selected while expected 1");
+          }
+          tree.clickOnRow(2);
+          if (stree.getSelectionRows()[0] != 2) {
+               errors.add(stree.getSelectionRows()[0] + " row is selected while expected 2");
+          }
+
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("Visible row count changes after clicking on row");
+          }
+          if (initSelected != stree.getSelection().length) {
+               errors.add("Selected row count changed: was " + initSelected + " now " + stree.getSelection().length);
+          }
+
+          tree.clickOnCheckbox(0);
+          if (stree.getSelection().length != 0) {
+               errors.add("There are " + stree.getSelection().length + " selected row while 0 expected");
+          }
+          tree.clickOnCheckbox(1);
+          if (stree.getSelection().length != 1) {
+               errors.add("There are " + stree.getSelection().length + " selected row while 1 expected");
+          }
+          tree.clickOnCheckbox(2);
+          if (stree.getSelection().length != 2) {
+               errors.add("There are " + stree.getSelection().length + " selected row while 1 expected (root)");
+          }
+
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("Visible row count changes after clicking on checkbox");
+          }
+
+          tree.clickOnArrow(0);
+          if (tree.getRowCount() != 1) {
+               errors.add("Tree is not collapsed after clicking on first row. Rows visible: " + tree.getRowCount());
+          }
+
+          tree.clickOnArrow(0);
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("Tree is not expanded after clicking on first row");
+          }
+
+          tree.clickOnArrow(2);
+          if (tree.getRowCount() == initRowCount) {
+               errors.add("Tree is not expanded after clicking on 2 row. Rows visible: " + tree.getRowCount());
+          }
+          initRowCount = tree.getRowCount();
+
+          tree.clickOnArrow(0);
+          if (tree.getRowCount() != 1) {
+               errors.add("Tree is not collapsed after clicking on first row. Rows visible: " + tree.getRowCount());
+          }
+
+          tree.clickOnArrow(0);
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("Tree is not expanded after clicking on first row");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree2.java
+++ b/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree2.java
@@ -1,0 +1,86 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_TestTree;
+
+import com.sun.interview.wizard.selectiontree.SelectionTree;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_TestTree2 extends Test {
+     /**
+      * This test verifies that multiple tests can be chosen and executed in Test
+      * Tree by pressing right mouse button -> Execute Tests.
+      */
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          Configuration conf = mainFrame.getConfiguration();
+          conf.load(CONFIG_NAME, true);
+
+          ConfigDialog cd = conf.openByMenu(true);
+          ConfigDialog.QuestionTree tree = cd.getQuestionTree();
+
+          int initRowCount = tree.getRowCount();
+          SelectionTree stree = tree.getTree();
+          int initSelected = stree.getSelection().length;
+          if (initRowCount != 4) {
+               errors.add("Initially there are 4 visible rows in the tree");
+          }
+          if (initSelected != 1) {
+               errors.add("Initially there are " + initSelected + " selected rows in the tree while 1 (root) expected");
+          }
+
+          tree.openContextMenu(-1).pushCollapseAll();
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 3");
+          }
+
+          tree.openContextMenu(-1).pushExpandAll();
+          if (tree.getRowCount() != 29) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 29");
+          }
+
+          tree.openContextMenu(-1).pushCollapseAll();
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 3 (after collapsing)");
+          }
+
+          tree.openContextMenu(-1).pushDeselectAll();
+          if (stree.getSelection().length != 0) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 0");
+          }
+
+          tree.openContextMenu(-1).pushSelectAll();
+          if (stree.getSelection().length != 1) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 1");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree3.java
@@ -1,0 +1,99 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_TestTree;
+
+import com.sun.interview.wizard.selectiontree.SelectionTree;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_TestTree3 extends Test {
+     /**
+      * This test verifies that multiple test results can be cleared Test Tree by
+      * pressing right mouse button -> Clear Results.
+      */
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          Configuration conf = mainFrame.getConfiguration();
+          conf.load(CONFIG_NAME, true);
+
+          ConfigDialog cd = conf.openByMenu(true);
+          ConfigDialog.QuestionTree tree = cd.getQuestionTree();
+
+          int initRowCount = tree.getRowCount();
+          SelectionTree stree = tree.getTree();
+          int initSelected = stree.getSelection().length;
+          if (initRowCount != 4) {
+               errors.add("Initially there are not 4 visible rows in the tree");
+          }
+          if (initSelected != 1) {
+               errors.add("Initially there are " + initSelected + " selected rows in the tree while 1 (root) expected");
+          }
+
+          tree.openContextMenu(-1).pushExpandAll();
+          if (tree.getRowCount() != 29) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 29");
+          }
+
+          tree.clickOnCheckbox(7);
+          tree.clickOnCheckbox(8);
+          if (stree.getSelection().length != 6) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 6");
+          }
+
+          tree.openContextMenu(9).pushSelectAll();
+          if (stree.getSelection().length != 7) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 7");
+          }
+
+          tree.openContextMenu(1).pushDeselectAll();
+          tree.clickOnCheckbox(10);
+          if (stree.getSelection().length != 4) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 4");
+          }
+
+          tree.openContextMenu(0).pushDeselectAll();
+          if (stree.getSelection().length != 0) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 0");
+          }
+
+          tree.openContextMenu(3).pushSelectAll();
+          tree.openContextMenu(4).pushSelectAll();
+          if (stree.getSelection().length != 2) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 2");
+          }
+
+          tree.openContextMenu(9).pushCollapseAll();
+          if (tree.getRowCount() != 25) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 25");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/New/New9.java
+++ b/gui-tests/src/gui/src/jthtest/New/New9.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.New;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public class New9 extends New {
+     /**
+      * This test case verifies that creating an existing workdirectory will create
+      * an error message.
+      */
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.New.New9");
+     }
+
+     @Test
+     public void testNew9() {
+          startTestRun(quickStartDialog);
+
+          next(quickStartDialog);
+
+          pickDefaultTestsuite(quickStartDialog);
+
+          next(quickStartDialog);
+
+          createConfiguration(quickStartDialog);
+
+          next(quickStartDialog);
+
+          pickExistingWorkDir(quickStartDialog);
+
+          next(quickStartDialog);
+
+          new JDialogOperator(mainFrame, "Error");
+     }
+
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. Config_TestTree1.java
2. Config_TestTree2.java
3. Config_TestTree3.java
4. Config_Load7.java
5. new9.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903700](https://bugs.openjdk.org/browse/CODETOOLS-7903700): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jtharness.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/63.diff">https://git.openjdk.org/jtharness/pull/63.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/63#issuecomment-2020975646)