### PR TITLE
7903701: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load7.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load7.java
@@ -1,0 +1,65 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_Load;
+
+import jthtest.ConfigTools;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class Config_Load7 extends Test {
+
+    public void testImpl() throws Exception {
+     JTFrame mainFrame = new JTFrame(true);
+
+     mainFrame.openDefaultTestSuite();
+     addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+     Configuration configuration = mainFrame.getConfiguration();
+     configuration.load(ConfigTools.CONFIG_NAME, true);
+
+     ConfigDialog config = configuration.openByKey();
+     config.load(ConfigTools.SECOND_CONFIG_NAME, true);
+
+     verifyOpeningNewConfigFile(config);
+    }
+
+    private boolean verifyOpeningNewConfigFile(ConfigDialog config) {
+     JListOperator list = new JListOperator(config.getConfigDialog());
+     list.selectItem(1);
+     return new JTextFieldOperator(config.getConfigDialog(), new NameComponentChooser("str.txt")).getText().equals(ConfigTools.SECOND_CONFIG_NAME);
+    }
+
+    @Override
+    public String getDescription() {
+     return "Load a configuration, open Configuration Editor. Load another configuration from it. Configuration Editor internals should be repainted";
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree1.java
+++ b/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree1.java
@@ -1,0 +1,124 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_TestTree;
+
+import com.sun.interview.wizard.selectiontree.SelectionTree;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_TestTree1 extends Test {
+     /**
+      * This test case verifies that selecting number of tests during execution will
+      * not change from what was selected.
+      */
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          Configuration conf = mainFrame.getConfiguration();
+          conf.load(CONFIG_NAME, true);
+
+          ConfigDialog cd = conf.openByMenu(true);
+          ConfigDialog.QuestionTree tree = cd.getQuestionTree();
+
+          int initRowCount = tree.getRowCount();
+          SelectionTree stree = tree.getTree();
+          int initSelected = stree.getSelection().length;
+          if (initRowCount != 4) {
+               errors.add("Initially there are not 3 visible rows in the tree");
+          }
+          if (initSelected != 1) {
+               errors.add("Initially there are " + initSelected + " selected rows in the tree while 1 (root) expected");
+          }
+
+          tree.clickOnRow(0);
+          if (stree.getSelectionRows()[0] != 0) {
+               errors.add(stree.getSelectionRows()[0] + " row is selected while expected 0");
+          }
+          tree.clickOnRow(1);
+          if (stree.getSelectionRows()[0] != 1) {
+               errors.add(stree.getSelectionRows()[0] + " row is selected while expected 1");
+          }
+          tree.clickOnRow(2);
+          if (stree.getSelectionRows()[0] != 2) {
+               errors.add(stree.getSelectionRows()[0] + " row is selected while expected 2");
+          }
+
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("Visible row count changes after clicking on row");
+          }
+          if (initSelected != stree.getSelection().length) {
+               errors.add("Selected row count changed: was " + initSelected + " now " + stree.getSelection().length);
+          }
+
+          tree.clickOnCheckbox(0);
+          if (stree.getSelection().length != 0) {
+               errors.add("There are " + stree.getSelection().length + " selected row while 0 expected");
+          }
+          tree.clickOnCheckbox(1);
+          if (stree.getSelection().length != 1) {
+               errors.add("There are " + stree.getSelection().length + " selected row while 1 expected");
+          }
+          tree.clickOnCheckbox(2);
+          if (stree.getSelection().length != 2) {
+               errors.add("There are " + stree.getSelection().length + " selected row while 1 expected (root)");
+          }
+
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("Visible row count changes after clicking on checkbox");
+          }
+
+          tree.clickOnArrow(0);
+          if (tree.getRowCount() != 1) {
+               errors.add("Tree is not collapsed after clicking on first row. Rows visible: " + tree.getRowCount());
+          }
+
+          tree.clickOnArrow(0);
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("Tree is not expanded after clicking on first row");
+          }
+
+          tree.clickOnArrow(2);
+          if (tree.getRowCount() == initRowCount) {
+               errors.add("Tree is not expanded after clicking on 2 row. Rows visible: " + tree.getRowCount());
+          }
+          initRowCount = tree.getRowCount();
+
+          tree.clickOnArrow(0);
+          if (tree.getRowCount() != 1) {
+               errors.add("Tree is not collapsed after clicking on first row. Rows visible: " + tree.getRowCount());
+          }
+
+          tree.clickOnArrow(0);
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("Tree is not expanded after clicking on first row");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree2.java
+++ b/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree2.java
@@ -1,0 +1,86 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_TestTree;
+
+import com.sun.interview.wizard.selectiontree.SelectionTree;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_TestTree2 extends Test {
+     /**
+      * This test verifies that multiple tests can be chosen and executed in Test
+      * Tree by pressing right mouse button -> Execute Tests.
+      */
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          Configuration conf = mainFrame.getConfiguration();
+          conf.load(CONFIG_NAME, true);
+
+          ConfigDialog cd = conf.openByMenu(true);
+          ConfigDialog.QuestionTree tree = cd.getQuestionTree();
+
+          int initRowCount = tree.getRowCount();
+          SelectionTree stree = tree.getTree();
+          int initSelected = stree.getSelection().length;
+          if (initRowCount != 4) {
+               errors.add("Initially there are 4 visible rows in the tree");
+          }
+          if (initSelected != 1) {
+               errors.add("Initially there are " + initSelected + " selected rows in the tree while 1 (root) expected");
+          }
+
+          tree.openContextMenu(-1).pushCollapseAll();
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 3");
+          }
+
+          tree.openContextMenu(-1).pushExpandAll();
+          if (tree.getRowCount() != 29) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 29");
+          }
+
+          tree.openContextMenu(-1).pushCollapseAll();
+          if (tree.getRowCount() != initRowCount) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 3 (after collapsing)");
+          }
+
+          tree.openContextMenu(-1).pushDeselectAll();
+          if (stree.getSelection().length != 0) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 0");
+          }
+
+          tree.openContextMenu(-1).pushSelectAll();
+          if (stree.getSelection().length != 1) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 1");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree3.java
+++ b/gui-tests/src/gui/src/jthtest/Config_TestTree/Config_TestTree3.java
@@ -1,0 +1,99 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_TestTree;
+
+import com.sun.interview.wizard.selectiontree.SelectionTree;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+
+public class Config_TestTree3 extends Test {
+     /**
+      * This test verifies that multiple test results can be cleared Test Tree by
+      * pressing right mouse button -> Clear Results.
+      */
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          Configuration conf = mainFrame.getConfiguration();
+          conf.load(CONFIG_NAME, true);
+
+          ConfigDialog cd = conf.openByMenu(true);
+          ConfigDialog.QuestionTree tree = cd.getQuestionTree();
+
+          int initRowCount = tree.getRowCount();
+          SelectionTree stree = tree.getTree();
+          int initSelected = stree.getSelection().length;
+          if (initRowCount != 4) {
+               errors.add("Initially there are not 4 visible rows in the tree");
+          }
+          if (initSelected != 1) {
+               errors.add("Initially there are " + initSelected + " selected rows in the tree while 1 (root) expected");
+          }
+
+          tree.openContextMenu(-1).pushExpandAll();
+          if (tree.getRowCount() != 29) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 29");
+          }
+
+          tree.clickOnCheckbox(7);
+          tree.clickOnCheckbox(8);
+          if (stree.getSelection().length != 6) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 6");
+          }
+
+          tree.openContextMenu(9).pushSelectAll();
+          if (stree.getSelection().length != 7) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 7");
+          }
+
+          tree.openContextMenu(1).pushDeselectAll();
+          tree.clickOnCheckbox(10);
+          if (stree.getSelection().length != 4) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 4");
+          }
+
+          tree.openContextMenu(0).pushDeselectAll();
+          if (stree.getSelection().length != 0) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 0");
+          }
+
+          tree.openContextMenu(3).pushSelectAll();
+          tree.openContextMenu(4).pushSelectAll();
+          if (stree.getSelection().length != 2) {
+               errors.add("There are " + stree.getSelection().length + " selected rows while expected 2");
+          }
+
+          tree.openContextMenu(9).pushCollapseAll();
+          if (tree.getRowCount() != 25) {
+               errors.add("There are " + tree.getRowCount() + " visible rows while expected 25");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/New/New9.java
+++ b/gui-tests/src/gui/src/jthtest/New/New9.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.New;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public class New9 extends New {
+     /**
+      * This test case verifies that creating an existing workdirectory will create
+      * an error message.
+      */
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.New.New9");
+     }
+
+     @Test
+     public void testNew9() {
+          startTestRun(quickStartDialog);
+
+          next(quickStartDialog);
+
+          pickDefaultTestsuite(quickStartDialog);
+
+          next(quickStartDialog);
+
+          createConfiguration(quickStartDialog);
+
+          next(quickStartDialog);
+
+          pickExistingWorkDir(quickStartDialog);
+
+          next(quickStartDialog);
+
+          new JDialogOperator(mainFrame, "Error");
+     }
+
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu01.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu01.java
@@ -1,0 +1,258 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.menu;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.MenuElement;
+import jthtest.Test;
+import jthtest.Tools;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuItemOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import static jthtest.menu.Menu.*;
+
+public class Menu01 extends Test {
+
+     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, Exception {
+          Tools.startJavatestNewDesktop();
+
+          JFrameOperator mainFrame = Tools.findMainFrame();
+          JMenuBarOperator menu = getMenuBar(mainFrame);
+
+          MenuElement[] menuElements = menu.getSubElements();
+          int menuCount = menuElements.length;
+          if (menuCount != 4) {
+               StringBuilder message = new StringBuilder("Found less then 4 menu elements. Expected ");
+               message.append(getFileMenuName()).append(", ");
+               message.append(getToolsMenuName()).append(", ");
+               message.append(getWindowsMenuName()).append(", ");
+               message.append(getHelpMenuName());
+               message.append(", found: ");
+               for (int i = 0; i < menuCount; i++) {
+                    message.append(((JMenuItem) menuElements[i].getComponent()).getText());
+               }
+               errors.add(message.toString());
+          }
+
+          if (menuCount > 0) {
+               JMenuOperator item = new JMenuOperator((JMenu) (menuElements[0].getComponent()));
+
+               String menuName = getFileMenuName();
+               System.out.println("menuName" + menuName);
+
+               if (!menuName.equals(item.getText())) {
+                    errors.add("First menu element is not " + menuName + ". Found " + item.getText());
+               } else {
+                    JMenuItemOperator[] elements = menu.showMenuItems(menuName);
+                    if (elements.length != 6) {
+                         StringBuilder message = new StringBuilder("Expected 8 File menu subelements: ");
+                         message.append(getFile_OpenQuickStartMenuName()).append(", ").append(getFile_OpenMenuName())
+                                   .append(", ");
+                         message.append(getFile_RecentWorkDirectoryMenuName()).append(", ")
+                                   .append(getFile_PreferencesMenuName());
+                         message.append(", ").append(getFile_CloseMenuName()).append(", ").append(getFile_ExitMenuName())
+                                   .append(". Found: ");
+                         for (JMenuItemOperator e : elements) {
+                              message.append(((JMenuItem) e.getComponent()).getText()).append("; ");
+                         }
+
+                         errors.add(message.toString());
+                    }
+                    if (elements.length > 0) {
+                         JMenuItem subitem = (JMenuItem) elements[0].getComponent();
+                         System.out.println("subitem.getText()" + subitem.getText());
+                         if (!getFile_OpenQuickStartMenuName().equals(subitem.getText())) {
+                              errors.add("First menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + getFile_OpenQuickStartMenuName());
+                         }
+                    }
+                    if (elements.length > 1) {
+                         JMenuItem subitem = (JMenuItem) elements[1].getComponent();
+                         if (!getFile_OpenMenuName().equals(subitem.getText())) {
+                              errors.add("Second menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + getFile_OpenMenuName());
+                         } else {
+                              JMenuItemOperator openSubElements[] = menu.showMenuItems(new String[] { menuName, "Open" },
+                                        new Tools.SimpleStringComparator());
+
+                              if (openSubElements.length != 2) {
+                                   errors.add("File->Open menu contains " + openSubElements.length + " while expected 2. ");
+                              }
+
+                              if (openSubElements.length > 0) {
+                                   JMenuItemOperator subsubitem = openSubElements[0];
+                                   if (!getFile_Open_WorkDirectoryMenuName().equals(subsubitem.getText())) {
+                                        errors.add("First menu subelement of File->Open menu is " + subsubitem.getText()
+                                                  + " while expected " + Menu.getFile_Open_WorkDirectoryMenuName());
+                                   }
+                              }
+                              if (openSubElements.length > 1) {
+                                   JMenuItemOperator subsubitem = openSubElements[1];
+                                   if (!getFile_Open_TestSuiteMenuName().equals(subsubitem.getText())) {
+                                        errors.add("First menu subelement of File->Open menu is " + subsubitem.getText()
+                                                  + " while expected " + Menu.getFile_Open_TestSuiteMenuName());
+                                   }
+                              }
+                         }
+
+                    }
+                    if (elements.length > 2) {
+                         JMenuItem subitem = (JMenuItem) elements[2].getComponent();
+                         if (!getFile_RecentWorkDirectoryMenuName().equals(subitem.getText())) {
+                              errors.add("Third menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + Menu.getFile_RecentWorkDirectoryMenuName());
+                         } else {
+                              MenuElement[] subElements = subitem.getSubElements();
+                              if (subElements.length != 1) {
+                                   errors.add("File->RecentWorkDirectort menu contains " + subElements.length
+                                             + " subelements while expected 1");
+                              }
+                         }
+                    }
+                    if (elements.length > 3) {
+                         JMenuItem subitem = (JMenuItem) elements[3].getComponent();
+                         if (!getFile_PreferencesMenuName().equals(subitem.getText())) {
+                              errors.add("Fifth menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + Menu.getFile_PreferencesMenuName());
+                         }
+                    }
+                    if (elements.length > 4) {
+                         JMenuItem subitem = (JMenuItem) elements[4].getComponent();
+                         if (!getFile_CloseMenuName().equals(subitem.getText())) {
+                              errors.add("Seventh menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + Menu.getFile_CloseMenuName());
+                         }
+                    }
+                    if (elements.length > 5) {
+                         JMenuItem subitem = (JMenuItem) elements[5].getComponent();
+                         if (!getFile_ExitMenuName().equals(subitem.getText())) {
+                              errors.add("Last menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + Menu.getFile_ExitMenuName());
+                         }
+                    }
+               }
+          }
+
+          if (menuCount > 1) {
+               JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[1].getComponent());
+
+               String menuName = getToolsMenuName();
+
+               if (!menuName.equals(item.getText())) {
+                    errors.add("Second menu element is not " + menuName + ". Found " + item.getText());
+               } else {
+                    JMenuItemOperator[] elements = menu.showMenuItems(menuName, new Tools.SimpleStringComparator());
+                    System.out.println(elements);
+                    if (elements.length != 3) {
+                         errors.add("Tools menu contains " + elements.length + " while expected 4. ");
+                    }
+
+                    String[] elementsNames = new String[elements.length];
+                    int i = 0;
+                    for (JMenuItemOperator op : elements) {
+                         elementsNames[i++] = op.getText();
+                    }
+                    Arrays.sort(elementsNames);
+                    int num = 0;
+                    if (elements.length > num) {
+                         String subitemName = elementsNames[num];
+                         String name = getTools_AgentMonitorMenuName();
+                         if (!name.equals(subitemName)) {
+                              errors.add("First menu subelement of Tools menu is " + subitemName + " while expected " + name);
+                         }
+                    }
+                    num = 1;
+                    if (elements.length > num) {
+                         String subitemName = elementsNames[num];
+                         // String name = getTools_OpenQuickStartWizardMenuName();
+                         String name = getTools_ReportConverterMenuName();
+                         if (!name.equals(subitemName)) {
+                              errors.add("First menu subelement of Tools menu is " + subitemName + " while expected " + name);
+                         }
+                    }
+               }
+          }
+
+          if (menuCount > 2) {
+               JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[2].getComponent());
+               String menuName = getWindowsMenuName();
+               if (!menuName.equals(item.getText())) {
+                    errors.add("Third menu element is not " + menuName + ". Found " + item.getText());
+               }
+          }
+
+          if (menuCount > 3) {
+               JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[3].getComponent());
+
+               String menuName = getHelpMenuName();
+
+               if (!menuName.equals(item.getText())) {
+                    errors.add("Fourth menu element is not " + menuName + ". Found " + item.getText());
+               } else {
+                    JMenuItemOperator[] elements = menu.showMenuItems(menuName);
+
+                    if (elements.length != 3) {
+                         errors.add("Help menu contains " + elements.length + " while expected 4. ");
+                    }
+
+                    if (elements.length > 0) {
+                         JMenuItemOperator subitem = elements[0];
+                         String name = getHelp_OnlineHelpMenuName();
+                         if (!name.equals(subitem.getText())) {
+                              errors.add("First menu subelement of menu Help is " + subitem.getText() + " while expected "
+                                        + name);
+                         }
+                    }
+                    if (elements.length > 1) {
+                         JMenuItemOperator subitem = elements[1];
+                         String name = getHelp_AboutJTHarnessMenuName();
+                         if (!name.equals(subitem.getText())) {
+                              errors.add("Second menu subelement of menu Help is " + subitem.getText() + " while expected "
+                                        + name);
+                         }
+                    }
+                    if (elements.length > 2) {
+                         JMenuItemOperator subitem = elements[2];
+                         String name = getHelp_AboutJVMMenuName();
+                         if (!name.equals(subitem.getText())) {
+                              errors.add("Third menu subelement of menu Help is " + subitem.getText() + " while expected "
+                                        + name);
+                         }
+                    }
+               }
+          }
+     }
+
+     @Override
+     public String getDescription() {
+          return "This test checks menu items in \"NewDesktop\" JavaTest frame. Tools menu subelements are checked sorted";
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu02.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu02.java
@@ -1,0 +1,60 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.menu;
+
+import jthtest.Test;
+import jthtest.Tools;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import static jthtest.menu.Menu.*;
+
+
+public class Menu02 extends Test {
+
+    @Override
+    public void testImpl() throws Exception {
+     Tools.startJavatestNewDesktop();
+
+     JFrameOperator op = Tools.findMainFrame();
+
+     getFileMenu(op);
+     getFile_CloseMenu(op);
+     getFile_ExitMenu(op);
+     getFile_OpenMenu(op);
+     getFile_OpenQuickStartMenu(op);
+     getFile_Open_TestSuiteMenu(op);
+     getFile_Open_WorkDirectoryMenu(op);
+     getFile_PreferencesMenu(op);
+     getFile_RecentWorkDirectoryMenu(op);
+    }
+
+    @Override
+    public String getDescription() {
+     return "This test checks internal methods are working. NewDesktop JavaTest is used";
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu03.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu03.java
@@ -1,0 +1,76 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.menu;
+
+import jthtest.Test;
+import static jthtest.Tools.*;
+import static jthtest.menu.Menu.*;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuItemOperator;
+
+public class Menu03 extends Test {
+
+    @Override
+    public void testImpl() throws Exception {
+     startJavatest();
+
+     JFrameOperator mainFrame = findMainFrame();
+     openTestSuite(mainFrame);
+
+     JMenuItemOperator item;
+     getFile_CreateWorkDirectoryMenu(mainFrame);
+     getConfigureMenu(mainFrame);
+     item = getConfigure_EditConfigurationMenu(mainFrame);
+     if(item.isEnabled())
+         errors.add("Configure->Edit Configuration menu is enabled while expected to be disabled");
+     item = getConfigure_EditQuickSetMenu(mainFrame);
+     if(item.isEnabled())
+         errors.add("Configure->Edit Quick Set menu is enabled while expected to be disabled");
+     getConfigure_LoadConfigurationMenu(mainFrame);
+     getConfigure_LoadRecentConfigurationMenu(mainFrame);
+     getConfigure_NewConfigurationMenu(mainFrame);
+
+     getRunTestsMenu(mainFrame);
+     getRunTests_MonitorProgressMenu(mainFrame);
+     getRunTests_StartMenu(mainFrame);
+     getRunTests_StopMenu(mainFrame);
+
+     getReportMenu(mainFrame);
+     getReport_CreateReportMenu(mainFrame);
+     getReport_OpenReportMenu(mainFrame);
+
+     getViewMenu(mainFrame);
+     getView_ConfigurationMenu(mainFrame);
+     getView_FilterMenu(mainFrame);
+     getView_LogsMenu(mainFrame);
+     getView_PropertiesMenu(mainFrame);
+     getView_TestSuiteErrorsMenu(mainFrame);
+
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu04.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu04.java
@@ -1,0 +1,131 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.menu;
+
+import jthtest.ConfigTools;
+import jthtest.Test;
+
+import jthtest.tools.JTFrame;
+import jthtest.workdir.Workdir;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import static jthtest.Tools.*;
+import static jthtest.menu.Menu.*;
+
+public class Menu04 extends Test {
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          if (mainFrame.getFile_CloseMenu().isEnabled()) {
+               errors.add("File->Close menu is enabled when unexpected (NewDesktop)");
+          }
+
+          mainFrame.openDefaultTestSuite();
+
+          if (!mainFrame.getFile_CloseMenu().isEnabled()) {
+               errors.add("File->Close menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
+
+          if (mainFrame.getConfigure_EditConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Edit Configuration menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (mainFrame.getConfigure_EditQuickSetMenu().isEnabled()) {
+               errors.add("Configure->Edit Quick Set menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Load Recent Configuration menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Load Configuration menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (!mainFrame.getConfigure_NewConfigurationMenu().isEnabled()) {
+               errors.add("Configure->New Configuration menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
+
+          if (mainFrame.getReport_CreateReportMenu().isEnabled()) {
+               errors.add("Report->Create Report menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (mainFrame.getReport_OpenReportMenu().isEnabled()) {
+               errors.add("Report->Open Report menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+
+          if (!mainFrame.getView_PropertiesMenu().isEnabled()) {
+               errors.add("View->Properties menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (mainFrame.getView_LogsMenu().isEnabled()) {
+               errors.add("View->Logs menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (!mainFrame.getView_Configuration_ShowChecklistMenu().isEnabled()) {
+               errors.add("View->Configuration->Show Checklist menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
+
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+          if (mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Load Recent Configuration menu is enabled when unexpected (TS selected, WD created, no config)");
+          }
+
+          if (!mainFrame.getView_PropertiesMenu().isEnabled()) {
+               errors.add("View->Properties menu is disabled when unexpected (TS selected, WD created, no config)");
+          }
+          if (!mainFrame.getView_LogsMenu().isEnabled()) {
+               errors.add("View->Logs menu is disabled when unexpected (TS selected, WD created, no config)");
+          }
+          if (!mainFrame.getReport_CreateReportMenu().isEnabled()) {
+               errors.add("Report->Create Report menu is disabled when unexpected (TS selected, WD created, no config)");
+          }
+          if (!mainFrame.getReport_OpenReportMenu().isEnabled()) {
+               errors.add("Report->Open Report menu is disabled when unexpected (TS selected, WD created, no config)");
+          }
+          if (mainFrame.getView_Configuration_ShowChecklistMenu().isEnabled()) {
+               errors.add("View->Configuration->Show Checklist menu is enabled when unexpected (TS selected, WD created, no config)");
+          }
+
+          mainFrame.getConfiguration().load(CONFIG_NAME, true);
+
+          if (!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Load Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+          }
+          if (!mainFrame.getConfigure_NewConfigurationMenu().isEnabled()) {
+               errors.add("Configure->New Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+          }
+          if (!mainFrame.getConfigure_EditConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Edit Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+          }
+          if (!mainFrame.getConfigure_EditQuickSetMenu().isEnabled()) {
+               errors.add("Configure->Edit Quick Set menu is disabled when unexpected (TS selected, WD created, config loaded)");
+          }
+
+     }
+
+     @Override
+     public String getDescription() {
+          return "This test checks that all menu items are enabled/disabled when it is needed. ";
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu05.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu05.java
@@ -1,0 +1,88 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.menu;
+
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.JTFrame;
+
+public class Menu05 extends Test {
+
+    public Menu05() {
+        depricated = true; // ConfigDialog is now modal, no need to block menu items
+    }
+
+    @Override
+    public void testImpl() throws Exception {
+     mainFrame = JTFrame.startJTWithDefaultWorkDirectory();
+
+     if(!mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+         errors.add("Configure->Edit Configuration menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+         errors.add("Configure->Edit Quick Set menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Configuration menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Recent Configuration menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+         errors.add("Configure->New Configuration menu is disabled before Configuration Editor is opened while unexpected");
+
+     ConfigDialog cd = mainFrame.getConfiguration().openByMenu(true);
+
+     if(mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+         errors.add("Configure->Edit Configuration menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+         errors.add("Configure->Edit Quick Set menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Configuration menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Recent Configuration menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+         errors.add("Configure->New Configuration menu is enabled while Configuration Editor is opened while unexpected");
+
+     cd.closeByMenu();
+
+     if(!mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+         errors.add("Configure->Edit Configuration menu is disabled after Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+         errors.add("Configure->Edit Quick Set menu is disabled after Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Configuration menu is disabled after Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Recent Configuration menu is disabled after Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+         errors.add("Configure->New Configuration menu is disabled after Configuration Editor is opened while unexpected");
+
+    }
+
+    @Override
+    public String getDescription() {
+     return "This test checks that all Configure menu subelements are disabled when Configuration Editor is opened and are enabled after it's closing";
+    }
+
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. Menu01.java
2. Menu02.java
3. Menu03.java
4. Menu04.java
5. Menu05.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jtharness.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/64.diff">https://git.openjdk.org/jtharness/pull/64.diff</a>

</details>
