### PR TITLE
7903701: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/menu/Menu01.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu01.java
@@ -41,218 +41,218 @@ import static jthtest.menu.Menu.*;
 
 public class Menu01 extends Test {
 
-	public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, Exception {
-		Tools.startJavatestNewDesktop();
+     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, Exception {
+          Tools.startJavatestNewDesktop();
 
-		JFrameOperator mainFrame = Tools.findMainFrame();
-		JMenuBarOperator menu = getMenuBar(mainFrame);
+          JFrameOperator mainFrame = Tools.findMainFrame();
+          JMenuBarOperator menu = getMenuBar(mainFrame);
 
-		MenuElement[] menuElements = menu.getSubElements();
-		int menuCount = menuElements.length;
-		if (menuCount != 4) {
-			StringBuilder message = new StringBuilder("Found less then 4 menu elements. Expected ");
-			message.append(getFileMenuName()).append(", ");
-			message.append(getToolsMenuName()).append(", ");
-			message.append(getWindowsMenuName()).append(", ");
-			message.append(getHelpMenuName());
-			message.append(", found: ");
-			for (int i = 0; i < menuCount; i++) {
-				message.append(((JMenuItem) menuElements[i].getComponent()).getText());
-			}
-			errors.add(message.toString());
-		}
+          MenuElement[] menuElements = menu.getSubElements();
+          int menuCount = menuElements.length;
+          if (menuCount != 4) {
+               StringBuilder message = new StringBuilder("Found less then 4 menu elements. Expected ");
+               message.append(getFileMenuName()).append(", ");
+               message.append(getToolsMenuName()).append(", ");
+               message.append(getWindowsMenuName()).append(", ");
+               message.append(getHelpMenuName());
+               message.append(", found: ");
+               for (int i = 0; i < menuCount; i++) {
+                    message.append(((JMenuItem) menuElements[i].getComponent()).getText());
+               }
+               errors.add(message.toString());
+          }
 
-		if (menuCount > 0) {
-			JMenuOperator item = new JMenuOperator((JMenu) (menuElements[0].getComponent()));
+          if (menuCount > 0) {
+               JMenuOperator item = new JMenuOperator((JMenu) (menuElements[0].getComponent()));
 
-			String menuName = getFileMenuName();
-			System.out.println("menuName" + menuName);
+               String menuName = getFileMenuName();
+               System.out.println("menuName" + menuName);
 
-			if (!menuName.equals(item.getText())) {
-				errors.add("First menu element is not " + menuName + ". Found " + item.getText());
-			} else {
-				JMenuItemOperator[] elements = menu.showMenuItems(menuName);
-				if (elements.length != 6) {
-					StringBuilder message = new StringBuilder("Expected 8 File menu subelements: ");
-					message.append(getFile_OpenQuickStartMenuName()).append(", ").append(getFile_OpenMenuName())
-							.append(", ");
-					message.append(getFile_RecentWorkDirectoryMenuName()).append(", ")
-							.append(getFile_PreferencesMenuName());
-					message.append(", ").append(getFile_CloseMenuName()).append(", ").append(getFile_ExitMenuName())
-							.append(". Found: ");
-					for (JMenuItemOperator e : elements) {
-						message.append(((JMenuItem) e.getComponent()).getText()).append("; ");
-					}
+               if (!menuName.equals(item.getText())) {
+                    errors.add("First menu element is not " + menuName + ". Found " + item.getText());
+               } else {
+                    JMenuItemOperator[] elements = menu.showMenuItems(menuName);
+                    if (elements.length != 6) {
+                         StringBuilder message = new StringBuilder("Expected 8 File menu subelements: ");
+                         message.append(getFile_OpenQuickStartMenuName()).append(", ").append(getFile_OpenMenuName())
+                                   .append(", ");
+                         message.append(getFile_RecentWorkDirectoryMenuName()).append(", ")
+                                   .append(getFile_PreferencesMenuName());
+                         message.append(", ").append(getFile_CloseMenuName()).append(", ").append(getFile_ExitMenuName())
+                                   .append(". Found: ");
+                         for (JMenuItemOperator e : elements) {
+                              message.append(((JMenuItem) e.getComponent()).getText()).append("; ");
+                         }
 
-					errors.add(message.toString());
-				}
-				if (elements.length > 0) {
-					JMenuItem subitem = (JMenuItem) elements[0].getComponent();
-					System.out.println("subitem.getText()" + subitem.getText());
-					if (!getFile_OpenQuickStartMenuName().equals(subitem.getText())) {
-						errors.add("First menu subelement of File menu is " + subitem.getText() + " while expected "
-								+ getFile_OpenQuickStartMenuName());
-					}
-				}
-				if (elements.length > 1) {
-					JMenuItem subitem = (JMenuItem) elements[1].getComponent();
-					if (!getFile_OpenMenuName().equals(subitem.getText())) {
-						errors.add("Second menu subelement of File menu is " + subitem.getText() + " while expected "
-								+ getFile_OpenMenuName());
-					} else {
-						JMenuItemOperator openSubElements[] = menu.showMenuItems(new String[] { menuName, "Open" },
-								new Tools.SimpleStringComparator());
+                         errors.add(message.toString());
+                    }
+                    if (elements.length > 0) {
+                         JMenuItem subitem = (JMenuItem) elements[0].getComponent();
+                         System.out.println("subitem.getText()" + subitem.getText());
+                         if (!getFile_OpenQuickStartMenuName().equals(subitem.getText())) {
+                              errors.add("First menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + getFile_OpenQuickStartMenuName());
+                         }
+                    }
+                    if (elements.length > 1) {
+                         JMenuItem subitem = (JMenuItem) elements[1].getComponent();
+                         if (!getFile_OpenMenuName().equals(subitem.getText())) {
+                              errors.add("Second menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + getFile_OpenMenuName());
+                         } else {
+                              JMenuItemOperator openSubElements[] = menu.showMenuItems(new String[] { menuName, "Open" },
+                                        new Tools.SimpleStringComparator());
 
-						if (openSubElements.length != 2) {
-							errors.add("File->Open menu contains " + openSubElements.length + " while expected 2. ");
-						}
+                              if (openSubElements.length != 2) {
+                                   errors.add("File->Open menu contains " + openSubElements.length + " while expected 2. ");
+                              }
 
-						if (openSubElements.length > 0) {
-							JMenuItemOperator subsubitem = openSubElements[0];
-							if (!getFile_Open_WorkDirectoryMenuName().equals(subsubitem.getText())) {
-								errors.add("First menu subelement of File->Open menu is " + subsubitem.getText()
-										+ " while expected " + Menu.getFile_Open_WorkDirectoryMenuName());
-							}
-						}
-						if (openSubElements.length > 1) {
-							JMenuItemOperator subsubitem = openSubElements[1];
-							if (!getFile_Open_TestSuiteMenuName().equals(subsubitem.getText())) {
-								errors.add("First menu subelement of File->Open menu is " + subsubitem.getText()
-										+ " while expected " + Menu.getFile_Open_TestSuiteMenuName());
-							}
-						}
-					}
+                              if (openSubElements.length > 0) {
+                                   JMenuItemOperator subsubitem = openSubElements[0];
+                                   if (!getFile_Open_WorkDirectoryMenuName().equals(subsubitem.getText())) {
+                                        errors.add("First menu subelement of File->Open menu is " + subsubitem.getText()
+                                                  + " while expected " + Menu.getFile_Open_WorkDirectoryMenuName());
+                                   }
+                              }
+                              if (openSubElements.length > 1) {
+                                   JMenuItemOperator subsubitem = openSubElements[1];
+                                   if (!getFile_Open_TestSuiteMenuName().equals(subsubitem.getText())) {
+                                        errors.add("First menu subelement of File->Open menu is " + subsubitem.getText()
+                                                  + " while expected " + Menu.getFile_Open_TestSuiteMenuName());
+                                   }
+                              }
+                         }
 
-				}
-				if (elements.length > 2) {
-					JMenuItem subitem = (JMenuItem) elements[2].getComponent();
-					if (!getFile_RecentWorkDirectoryMenuName().equals(subitem.getText())) {
-						errors.add("Third menu subelement of File menu is " + subitem.getText() + " while expected "
-								+ Menu.getFile_RecentWorkDirectoryMenuName());
-					} else {
-						MenuElement[] subElements = subitem.getSubElements();
-						if (subElements.length != 1) {
-							errors.add("File->RecentWorkDirectort menu contains " + subElements.length
-									+ " subelements while expected 1");
-						}
-					}
-				}
-				if (elements.length > 3) {
-					JMenuItem subitem = (JMenuItem) elements[3].getComponent();
-					if (!getFile_PreferencesMenuName().equals(subitem.getText())) {
-						errors.add("Fifth menu subelement of File menu is " + subitem.getText() + " while expected "
-								+ Menu.getFile_PreferencesMenuName());
-					}
-				}
-				if (elements.length > 4) {
-					JMenuItem subitem = (JMenuItem) elements[4].getComponent();
-					if (!getFile_CloseMenuName().equals(subitem.getText())) {
-						errors.add("Seventh menu subelement of File menu is " + subitem.getText() + " while expected "
-								+ Menu.getFile_CloseMenuName());
-					}
-				}
-				if (elements.length > 5) {
-					JMenuItem subitem = (JMenuItem) elements[5].getComponent();
-					if (!getFile_ExitMenuName().equals(subitem.getText())) {
-						errors.add("Last menu subelement of File menu is " + subitem.getText() + " while expected "
-								+ Menu.getFile_ExitMenuName());
-					}
-				}
-			}
-		}
+                    }
+                    if (elements.length > 2) {
+                         JMenuItem subitem = (JMenuItem) elements[2].getComponent();
+                         if (!getFile_RecentWorkDirectoryMenuName().equals(subitem.getText())) {
+                              errors.add("Third menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + Menu.getFile_RecentWorkDirectoryMenuName());
+                         } else {
+                              MenuElement[] subElements = subitem.getSubElements();
+                              if (subElements.length != 1) {
+                                   errors.add("File->RecentWorkDirectort menu contains " + subElements.length
+                                             + " subelements while expected 1");
+                              }
+                         }
+                    }
+                    if (elements.length > 3) {
+                         JMenuItem subitem = (JMenuItem) elements[3].getComponent();
+                         if (!getFile_PreferencesMenuName().equals(subitem.getText())) {
+                              errors.add("Fifth menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + Menu.getFile_PreferencesMenuName());
+                         }
+                    }
+                    if (elements.length > 4) {
+                         JMenuItem subitem = (JMenuItem) elements[4].getComponent();
+                         if (!getFile_CloseMenuName().equals(subitem.getText())) {
+                              errors.add("Seventh menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + Menu.getFile_CloseMenuName());
+                         }
+                    }
+                    if (elements.length > 5) {
+                         JMenuItem subitem = (JMenuItem) elements[5].getComponent();
+                         if (!getFile_ExitMenuName().equals(subitem.getText())) {
+                              errors.add("Last menu subelement of File menu is " + subitem.getText() + " while expected "
+                                        + Menu.getFile_ExitMenuName());
+                         }
+                    }
+               }
+          }
 
-		if (menuCount > 1) {
-			JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[1].getComponent());
+          if (menuCount > 1) {
+               JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[1].getComponent());
 
-			String menuName = getToolsMenuName();
+               String menuName = getToolsMenuName();
 
-			if (!menuName.equals(item.getText())) {
-				errors.add("Second menu element is not " + menuName + ". Found " + item.getText());
-			} else {
-				JMenuItemOperator[] elements = menu.showMenuItems(menuName, new Tools.SimpleStringComparator());
-				System.out.println(elements);
-				if (elements.length != 3) {
-					errors.add("Tools menu contains " + elements.length + " while expected 4. ");
-				}
+               if (!menuName.equals(item.getText())) {
+                    errors.add("Second menu element is not " + menuName + ". Found " + item.getText());
+               } else {
+                    JMenuItemOperator[] elements = menu.showMenuItems(menuName, new Tools.SimpleStringComparator());
+                    System.out.println(elements);
+                    if (elements.length != 3) {
+                         errors.add("Tools menu contains " + elements.length + " while expected 4. ");
+                    }
 
-				String[] elementsNames = new String[elements.length];
-				int i = 0;
-				for (JMenuItemOperator op : elements) {
-					elementsNames[i++] = op.getText();
-				}
-				Arrays.sort(elementsNames);
-				int num = 0;
-				if (elements.length > num) {
-					String subitemName = elementsNames[num];
-					String name = getTools_AgentMonitorMenuName();
-					if (!name.equals(subitemName)) {
-						errors.add("First menu subelement of Tools menu is " + subitemName + " while expected " + name);
-					}
-				}
-				num = 1;
-				if (elements.length > num) {
-					String subitemName = elementsNames[num];
-					// String name = getTools_OpenQuickStartWizardMenuName();
-					String name = getTools_ReportConverterMenuName();
-					if (!name.equals(subitemName)) {
-						errors.add("First menu subelement of Tools menu is " + subitemName + " while expected " + name);
-					}
-				}
-			}
-		}
+                    String[] elementsNames = new String[elements.length];
+                    int i = 0;
+                    for (JMenuItemOperator op : elements) {
+                         elementsNames[i++] = op.getText();
+                    }
+                    Arrays.sort(elementsNames);
+                    int num = 0;
+                    if (elements.length > num) {
+                         String subitemName = elementsNames[num];
+                         String name = getTools_AgentMonitorMenuName();
+                         if (!name.equals(subitemName)) {
+                              errors.add("First menu subelement of Tools menu is " + subitemName + " while expected " + name);
+                         }
+                    }
+                    num = 1;
+                    if (elements.length > num) {
+                         String subitemName = elementsNames[num];
+                         // String name = getTools_OpenQuickStartWizardMenuName();
+                         String name = getTools_ReportConverterMenuName();
+                         if (!name.equals(subitemName)) {
+                              errors.add("First menu subelement of Tools menu is " + subitemName + " while expected " + name);
+                         }
+                    }
+               }
+          }
 
-		if (menuCount > 2) {
-			JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[2].getComponent());
-			String menuName = getWindowsMenuName();
-			if (!menuName.equals(item.getText())) {
-				errors.add("Third menu element is not " + menuName + ". Found " + item.getText());
-			}
-		}
+          if (menuCount > 2) {
+               JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[2].getComponent());
+               String menuName = getWindowsMenuName();
+               if (!menuName.equals(item.getText())) {
+                    errors.add("Third menu element is not " + menuName + ". Found " + item.getText());
+               }
+          }
 
-		if (menuCount > 3) {
-			JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[3].getComponent());
+          if (menuCount > 3) {
+               JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[3].getComponent());
 
-			String menuName = getHelpMenuName();
+               String menuName = getHelpMenuName();
 
-			if (!menuName.equals(item.getText())) {
-				errors.add("Fourth menu element is not " + menuName + ". Found " + item.getText());
-			} else {
-				JMenuItemOperator[] elements = menu.showMenuItems(menuName);
+               if (!menuName.equals(item.getText())) {
+                    errors.add("Fourth menu element is not " + menuName + ". Found " + item.getText());
+               } else {
+                    JMenuItemOperator[] elements = menu.showMenuItems(menuName);
 
-				if (elements.length != 3) {
-					errors.add("Help menu contains " + elements.length + " while expected 4. ");
-				}
+                    if (elements.length != 3) {
+                         errors.add("Help menu contains " + elements.length + " while expected 4. ");
+                    }
 
-				if (elements.length > 0) {
-					JMenuItemOperator subitem = elements[0];
-					String name = getHelp_OnlineHelpMenuName();
-					if (!name.equals(subitem.getText())) {
-						errors.add("First menu subelement of menu Help is " + subitem.getText() + " while expected "
-								+ name);
-					}
-				}
-				if (elements.length > 1) {
-					JMenuItemOperator subitem = elements[1];
-					String name = getHelp_AboutJTHarnessMenuName();
-					if (!name.equals(subitem.getText())) {
-						errors.add("Second menu subelement of menu Help is " + subitem.getText() + " while expected "
-								+ name);
-					}
-				}
-				if (elements.length > 2) {
-					JMenuItemOperator subitem = elements[2];
-					String name = getHelp_AboutJVMMenuName();
-					if (!name.equals(subitem.getText())) {
-						errors.add("Third menu subelement of menu Help is " + subitem.getText() + " while expected "
-								+ name);
-					}
-				}
-			}
-		}
-	}
+                    if (elements.length > 0) {
+                         JMenuItemOperator subitem = elements[0];
+                         String name = getHelp_OnlineHelpMenuName();
+                         if (!name.equals(subitem.getText())) {
+                              errors.add("First menu subelement of menu Help is " + subitem.getText() + " while expected "
+                                        + name);
+                         }
+                    }
+                    if (elements.length > 1) {
+                         JMenuItemOperator subitem = elements[1];
+                         String name = getHelp_AboutJTHarnessMenuName();
+                         if (!name.equals(subitem.getText())) {
+                              errors.add("Second menu subelement of menu Help is " + subitem.getText() + " while expected "
+                                        + name);
+                         }
+                    }
+                    if (elements.length > 2) {
+                         JMenuItemOperator subitem = elements[2];
+                         String name = getHelp_AboutJVMMenuName();
+                         if (!name.equals(subitem.getText())) {
+                              errors.add("Third menu subelement of menu Help is " + subitem.getText() + " while expected "
+                                        + name);
+                         }
+                    }
+               }
+          }
+     }
 
-	@Override
-	public String getDescription() {
-		return "This test checks menu items in \"NewDesktop\" JavaTest frame. Tools menu subelements are checked sorted";
-	}
+     @Override
+     public String getDescription() {
+          return "This test checks menu items in \"NewDesktop\" JavaTest frame. Tools menu subelements are checked sorted";
+     }
 }

--- a/gui-tests/src/gui/src/jthtest/menu/Menu01.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu01.java
@@ -1,0 +1,258 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.menu;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.MenuElement;
+import jthtest.Test;
+import jthtest.Tools;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuItemOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import static jthtest.menu.Menu.*;
+
+public class Menu01 extends Test {
+
+	public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, Exception {
+		Tools.startJavatestNewDesktop();
+
+		JFrameOperator mainFrame = Tools.findMainFrame();
+		JMenuBarOperator menu = getMenuBar(mainFrame);
+
+		MenuElement[] menuElements = menu.getSubElements();
+		int menuCount = menuElements.length;
+		if (menuCount != 4) {
+			StringBuilder message = new StringBuilder("Found less then 4 menu elements. Expected ");
+			message.append(getFileMenuName()).append(", ");
+			message.append(getToolsMenuName()).append(", ");
+			message.append(getWindowsMenuName()).append(", ");
+			message.append(getHelpMenuName());
+			message.append(", found: ");
+			for (int i = 0; i < menuCount; i++) {
+				message.append(((JMenuItem) menuElements[i].getComponent()).getText());
+			}
+			errors.add(message.toString());
+		}
+
+		if (menuCount > 0) {
+			JMenuOperator item = new JMenuOperator((JMenu) (menuElements[0].getComponent()));
+
+			String menuName = getFileMenuName();
+			System.out.println("menuName" + menuName);
+
+			if (!menuName.equals(item.getText())) {
+				errors.add("First menu element is not " + menuName + ". Found " + item.getText());
+			} else {
+				JMenuItemOperator[] elements = menu.showMenuItems(menuName);
+				if (elements.length != 6) {
+					StringBuilder message = new StringBuilder("Expected 8 File menu subelements: ");
+					message.append(getFile_OpenQuickStartMenuName()).append(", ").append(getFile_OpenMenuName())
+							.append(", ");
+					message.append(getFile_RecentWorkDirectoryMenuName()).append(", ")
+							.append(getFile_PreferencesMenuName());
+					message.append(", ").append(getFile_CloseMenuName()).append(", ").append(getFile_ExitMenuName())
+							.append(". Found: ");
+					for (JMenuItemOperator e : elements) {
+						message.append(((JMenuItem) e.getComponent()).getText()).append("; ");
+					}
+
+					errors.add(message.toString());
+				}
+				if (elements.length > 0) {
+					JMenuItem subitem = (JMenuItem) elements[0].getComponent();
+					System.out.println("subitem.getText()" + subitem.getText());
+					if (!getFile_OpenQuickStartMenuName().equals(subitem.getText())) {
+						errors.add("First menu subelement of File menu is " + subitem.getText() + " while expected "
+								+ getFile_OpenQuickStartMenuName());
+					}
+				}
+				if (elements.length > 1) {
+					JMenuItem subitem = (JMenuItem) elements[1].getComponent();
+					if (!getFile_OpenMenuName().equals(subitem.getText())) {
+						errors.add("Second menu subelement of File menu is " + subitem.getText() + " while expected "
+								+ getFile_OpenMenuName());
+					} else {
+						JMenuItemOperator openSubElements[] = menu.showMenuItems(new String[] { menuName, "Open" },
+								new Tools.SimpleStringComparator());
+
+						if (openSubElements.length != 2) {
+							errors.add("File->Open menu contains " + openSubElements.length + " while expected 2. ");
+						}
+
+						if (openSubElements.length > 0) {
+							JMenuItemOperator subsubitem = openSubElements[0];
+							if (!getFile_Open_WorkDirectoryMenuName().equals(subsubitem.getText())) {
+								errors.add("First menu subelement of File->Open menu is " + subsubitem.getText()
+										+ " while expected " + Menu.getFile_Open_WorkDirectoryMenuName());
+							}
+						}
+						if (openSubElements.length > 1) {
+							JMenuItemOperator subsubitem = openSubElements[1];
+							if (!getFile_Open_TestSuiteMenuName().equals(subsubitem.getText())) {
+								errors.add("First menu subelement of File->Open menu is " + subsubitem.getText()
+										+ " while expected " + Menu.getFile_Open_TestSuiteMenuName());
+							}
+						}
+					}
+
+				}
+				if (elements.length > 2) {
+					JMenuItem subitem = (JMenuItem) elements[2].getComponent();
+					if (!getFile_RecentWorkDirectoryMenuName().equals(subitem.getText())) {
+						errors.add("Third menu subelement of File menu is " + subitem.getText() + " while expected "
+								+ Menu.getFile_RecentWorkDirectoryMenuName());
+					} else {
+						MenuElement[] subElements = subitem.getSubElements();
+						if (subElements.length != 1) {
+							errors.add("File->RecentWorkDirectort menu contains " + subElements.length
+									+ " subelements while expected 1");
+						}
+					}
+				}
+				if (elements.length > 3) {
+					JMenuItem subitem = (JMenuItem) elements[3].getComponent();
+					if (!getFile_PreferencesMenuName().equals(subitem.getText())) {
+						errors.add("Fifth menu subelement of File menu is " + subitem.getText() + " while expected "
+								+ Menu.getFile_PreferencesMenuName());
+					}
+				}
+				if (elements.length > 4) {
+					JMenuItem subitem = (JMenuItem) elements[4].getComponent();
+					if (!getFile_CloseMenuName().equals(subitem.getText())) {
+						errors.add("Seventh menu subelement of File menu is " + subitem.getText() + " while expected "
+								+ Menu.getFile_CloseMenuName());
+					}
+				}
+				if (elements.length > 5) {
+					JMenuItem subitem = (JMenuItem) elements[5].getComponent();
+					if (!getFile_ExitMenuName().equals(subitem.getText())) {
+						errors.add("Last menu subelement of File menu is " + subitem.getText() + " while expected "
+								+ Menu.getFile_ExitMenuName());
+					}
+				}
+			}
+		}
+
+		if (menuCount > 1) {
+			JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[1].getComponent());
+
+			String menuName = getToolsMenuName();
+
+			if (!menuName.equals(item.getText())) {
+				errors.add("Second menu element is not " + menuName + ". Found " + item.getText());
+			} else {
+				JMenuItemOperator[] elements = menu.showMenuItems(menuName, new Tools.SimpleStringComparator());
+				System.out.println(elements);
+				if (elements.length != 3) {
+					errors.add("Tools menu contains " + elements.length + " while expected 4. ");
+				}
+
+				String[] elementsNames = new String[elements.length];
+				int i = 0;
+				for (JMenuItemOperator op : elements) {
+					elementsNames[i++] = op.getText();
+				}
+				Arrays.sort(elementsNames);
+				int num = 0;
+				if (elements.length > num) {
+					String subitemName = elementsNames[num];
+					String name = getTools_AgentMonitorMenuName();
+					if (!name.equals(subitemName)) {
+						errors.add("First menu subelement of Tools menu is " + subitemName + " while expected " + name);
+					}
+				}
+				num = 1;
+				if (elements.length > num) {
+					String subitemName = elementsNames[num];
+					// String name = getTools_OpenQuickStartWizardMenuName();
+					String name = getTools_ReportConverterMenuName();
+					if (!name.equals(subitemName)) {
+						errors.add("First menu subelement of Tools menu is " + subitemName + " while expected " + name);
+					}
+				}
+			}
+		}
+
+		if (menuCount > 2) {
+			JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[2].getComponent());
+			String menuName = getWindowsMenuName();
+			if (!menuName.equals(item.getText())) {
+				errors.add("Third menu element is not " + menuName + ". Found " + item.getText());
+			}
+		}
+
+		if (menuCount > 3) {
+			JMenuItemOperator item = new JMenuItemOperator((JMenuItem) menuElements[3].getComponent());
+
+			String menuName = getHelpMenuName();
+
+			if (!menuName.equals(item.getText())) {
+				errors.add("Fourth menu element is not " + menuName + ". Found " + item.getText());
+			} else {
+				JMenuItemOperator[] elements = menu.showMenuItems(menuName);
+
+				if (elements.length != 3) {
+					errors.add("Help menu contains " + elements.length + " while expected 4. ");
+				}
+
+				if (elements.length > 0) {
+					JMenuItemOperator subitem = elements[0];
+					String name = getHelp_OnlineHelpMenuName();
+					if (!name.equals(subitem.getText())) {
+						errors.add("First menu subelement of menu Help is " + subitem.getText() + " while expected "
+								+ name);
+					}
+				}
+				if (elements.length > 1) {
+					JMenuItemOperator subitem = elements[1];
+					String name = getHelp_AboutJTHarnessMenuName();
+					if (!name.equals(subitem.getText())) {
+						errors.add("Second menu subelement of menu Help is " + subitem.getText() + " while expected "
+								+ name);
+					}
+				}
+				if (elements.length > 2) {
+					JMenuItemOperator subitem = elements[2];
+					String name = getHelp_AboutJVMMenuName();
+					if (!name.equals(subitem.getText())) {
+						errors.add("Third menu subelement of menu Help is " + subitem.getText() + " while expected "
+								+ name);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public String getDescription() {
+		return "This test checks menu items in \"NewDesktop\" JavaTest frame. Tools menu subelements are checked sorted";
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu02.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu02.java
@@ -1,0 +1,60 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.menu;
+
+import jthtest.Test;
+import jthtest.Tools;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import static jthtest.menu.Menu.*;
+
+
+public class Menu02 extends Test {
+
+    @Override
+    public void testImpl() throws Exception {
+	Tools.startJavatestNewDesktop();
+
+	JFrameOperator op = Tools.findMainFrame();
+
+	getFileMenu(op);
+	getFile_CloseMenu(op);
+	getFile_ExitMenu(op);
+	getFile_OpenMenu(op);
+	getFile_OpenQuickStartMenu(op);
+	getFile_Open_TestSuiteMenu(op);
+	getFile_Open_WorkDirectoryMenu(op);
+	getFile_PreferencesMenu(op);
+	getFile_RecentWorkDirectoryMenu(op);
+    }
+
+    @Override
+    public String getDescription() {
+	return "This test checks internal methods are working. NewDesktop JavaTest is used";
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu02.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu02.java
@@ -37,24 +37,24 @@ public class Menu02 extends Test {
 
     @Override
     public void testImpl() throws Exception {
-	Tools.startJavatestNewDesktop();
+     Tools.startJavatestNewDesktop();
 
-	JFrameOperator op = Tools.findMainFrame();
+     JFrameOperator op = Tools.findMainFrame();
 
-	getFileMenu(op);
-	getFile_CloseMenu(op);
-	getFile_ExitMenu(op);
-	getFile_OpenMenu(op);
-	getFile_OpenQuickStartMenu(op);
-	getFile_Open_TestSuiteMenu(op);
-	getFile_Open_WorkDirectoryMenu(op);
-	getFile_PreferencesMenu(op);
-	getFile_RecentWorkDirectoryMenu(op);
+     getFileMenu(op);
+     getFile_CloseMenu(op);
+     getFile_ExitMenu(op);
+     getFile_OpenMenu(op);
+     getFile_OpenQuickStartMenu(op);
+     getFile_Open_TestSuiteMenu(op);
+     getFile_Open_WorkDirectoryMenu(op);
+     getFile_PreferencesMenu(op);
+     getFile_RecentWorkDirectoryMenu(op);
     }
 
     @Override
     public String getDescription() {
-	return "This test checks internal methods are working. NewDesktop JavaTest is used";
+     return "This test checks internal methods are working. NewDesktop JavaTest is used";
     }
 
 }

--- a/gui-tests/src/gui/src/jthtest/menu/Menu03.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu03.java
@@ -1,0 +1,76 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.menu;
+
+import jthtest.Test;
+import static jthtest.Tools.*;
+import static jthtest.menu.Menu.*;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuItemOperator;
+
+public class Menu03 extends Test {
+
+    @Override
+    public void testImpl() throws Exception {
+	startJavatest();
+
+	JFrameOperator mainFrame = findMainFrame();
+	openTestSuite(mainFrame);
+
+	JMenuItemOperator item;
+	getFile_CreateWorkDirectoryMenu(mainFrame);
+	getConfigureMenu(mainFrame);
+	item = getConfigure_EditConfigurationMenu(mainFrame);
+	if(item.isEnabled())
+	    errors.add("Configure->Edit Configuration menu is enabled while expected to be disabled");
+	item = getConfigure_EditQuickSetMenu(mainFrame);
+	if(item.isEnabled())
+	    errors.add("Configure->Edit Quick Set menu is enabled while expected to be disabled");
+	getConfigure_LoadConfigurationMenu(mainFrame);
+	getConfigure_LoadRecentConfigurationMenu(mainFrame);
+	getConfigure_NewConfigurationMenu(mainFrame);
+
+	getRunTestsMenu(mainFrame);
+	getRunTests_MonitorProgressMenu(mainFrame);
+	getRunTests_StartMenu(mainFrame);
+	getRunTests_StopMenu(mainFrame);
+
+	getReportMenu(mainFrame);
+	getReport_CreateReportMenu(mainFrame);
+	getReport_OpenReportMenu(mainFrame);
+
+	getViewMenu(mainFrame);
+	getView_ConfigurationMenu(mainFrame);
+	getView_FilterMenu(mainFrame);
+	getView_LogsMenu(mainFrame);
+	getView_PropertiesMenu(mainFrame);
+	getView_TestSuiteErrorsMenu(mainFrame);
+	
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu03.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu03.java
@@ -37,40 +37,40 @@ public class Menu03 extends Test {
 
     @Override
     public void testImpl() throws Exception {
-	startJavatest();
+     startJavatest();
 
-	JFrameOperator mainFrame = findMainFrame();
-	openTestSuite(mainFrame);
+     JFrameOperator mainFrame = findMainFrame();
+     openTestSuite(mainFrame);
 
-	JMenuItemOperator item;
-	getFile_CreateWorkDirectoryMenu(mainFrame);
-	getConfigureMenu(mainFrame);
-	item = getConfigure_EditConfigurationMenu(mainFrame);
-	if(item.isEnabled())
-	    errors.add("Configure->Edit Configuration menu is enabled while expected to be disabled");
-	item = getConfigure_EditQuickSetMenu(mainFrame);
-	if(item.isEnabled())
-	    errors.add("Configure->Edit Quick Set menu is enabled while expected to be disabled");
-	getConfigure_LoadConfigurationMenu(mainFrame);
-	getConfigure_LoadRecentConfigurationMenu(mainFrame);
-	getConfigure_NewConfigurationMenu(mainFrame);
+     JMenuItemOperator item;
+     getFile_CreateWorkDirectoryMenu(mainFrame);
+     getConfigureMenu(mainFrame);
+     item = getConfigure_EditConfigurationMenu(mainFrame);
+     if(item.isEnabled())
+         errors.add("Configure->Edit Configuration menu is enabled while expected to be disabled");
+     item = getConfigure_EditQuickSetMenu(mainFrame);
+     if(item.isEnabled())
+         errors.add("Configure->Edit Quick Set menu is enabled while expected to be disabled");
+     getConfigure_LoadConfigurationMenu(mainFrame);
+     getConfigure_LoadRecentConfigurationMenu(mainFrame);
+     getConfigure_NewConfigurationMenu(mainFrame);
 
-	getRunTestsMenu(mainFrame);
-	getRunTests_MonitorProgressMenu(mainFrame);
-	getRunTests_StartMenu(mainFrame);
-	getRunTests_StopMenu(mainFrame);
+     getRunTestsMenu(mainFrame);
+     getRunTests_MonitorProgressMenu(mainFrame);
+     getRunTests_StartMenu(mainFrame);
+     getRunTests_StopMenu(mainFrame);
 
-	getReportMenu(mainFrame);
-	getReport_CreateReportMenu(mainFrame);
-	getReport_OpenReportMenu(mainFrame);
+     getReportMenu(mainFrame);
+     getReport_CreateReportMenu(mainFrame);
+     getReport_OpenReportMenu(mainFrame);
 
-	getViewMenu(mainFrame);
-	getView_ConfigurationMenu(mainFrame);
-	getView_FilterMenu(mainFrame);
-	getView_LogsMenu(mainFrame);
-	getView_PropertiesMenu(mainFrame);
-	getView_TestSuiteErrorsMenu(mainFrame);
-	
+     getViewMenu(mainFrame);
+     getView_ConfigurationMenu(mainFrame);
+     getView_FilterMenu(mainFrame);
+     getView_LogsMenu(mainFrame);
+     getView_PropertiesMenu(mainFrame);
+     getView_TestSuiteErrorsMenu(mainFrame);
+
     }
 
 }

--- a/gui-tests/src/gui/src/jthtest/menu/Menu04.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu04.java
@@ -1,0 +1,131 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.menu;
+
+import jthtest.ConfigTools;
+import jthtest.Test;
+
+import jthtest.tools.JTFrame;
+import jthtest.workdir.Workdir;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import static jthtest.Tools.*;
+import static jthtest.menu.Menu.*;
+
+public class Menu04 extends Test {
+
+	@Override
+	public void testImpl() throws Exception {
+		mainFrame = new JTFrame(true);
+
+		if (mainFrame.getFile_CloseMenu().isEnabled()) {
+			errors.add("File->Close menu is enabled when unexpected (NewDesktop)");
+		}
+
+		mainFrame.openDefaultTestSuite();
+
+		if (!mainFrame.getFile_CloseMenu().isEnabled()) {
+			errors.add("File->Close menu is disabled when unexpected (TS selected, no WD, no config)");
+		}
+
+		if (mainFrame.getConfigure_EditConfigurationMenu().isEnabled()) {
+			errors.add("Configure->Edit Configuration menu is enabled when unexpected (TS selected, no WD, no config)");
+		}
+		if (mainFrame.getConfigure_EditQuickSetMenu().isEnabled()) {
+			errors.add("Configure->Edit Quick Set menu is enabled when unexpected (TS selected, no WD, no config)");
+		}
+		if (mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled()) {
+			errors.add("Configure->Load Recent Configuration menu is enabled when unexpected (TS selected, no WD, no config)");
+		}
+		if (!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled()) {
+			errors.add("Configure->Load Configuration menu is disabled when unexpected (TS selected, no WD, no config)");
+		}
+		if (!mainFrame.getConfigure_NewConfigurationMenu().isEnabled()) {
+			errors.add("Configure->New Configuration menu is disabled when unexpected (TS selected, no WD, no config)");
+		}
+
+		if (mainFrame.getReport_CreateReportMenu().isEnabled()) {
+			errors.add("Report->Create Report menu is enabled when unexpected (TS selected, no WD, no config)");
+		}
+		if (mainFrame.getReport_OpenReportMenu().isEnabled()) {
+			errors.add("Report->Open Report menu is enabled when unexpected (TS selected, no WD, no config)");
+		}
+
+		if (!mainFrame.getView_PropertiesMenu().isEnabled()) {
+			errors.add("View->Properties menu is disabled when unexpected (TS selected, no WD, no config)");
+		}
+		if (mainFrame.getView_LogsMenu().isEnabled()) {
+			errors.add("View->Logs menu is enabled when unexpected (TS selected, no WD, no config)");
+		}
+		if (!mainFrame.getView_Configuration_ShowChecklistMenu().isEnabled()) {
+			errors.add("View->Configuration->Show Checklist menu is disabled when unexpected (TS selected, no WD, no config)");
+		}
+
+		addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+		if (mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled()) {
+			errors.add("Configure->Load Recent Configuration menu is enabled when unexpected (TS selected, WD created, no config)");
+		}
+
+		if (!mainFrame.getView_PropertiesMenu().isEnabled()) {
+			errors.add("View->Properties menu is disabled when unexpected (TS selected, WD created, no config)");
+		}
+		if (!mainFrame.getView_LogsMenu().isEnabled()) {
+			errors.add("View->Logs menu is disabled when unexpected (TS selected, WD created, no config)");
+		}
+		if (!mainFrame.getReport_CreateReportMenu().isEnabled()) {
+			errors.add("Report->Create Report menu is disabled when unexpected (TS selected, WD created, no config)");
+		}
+		if (!mainFrame.getReport_OpenReportMenu().isEnabled()) {
+			errors.add("Report->Open Report menu is disabled when unexpected (TS selected, WD created, no config)");
+		}
+		if (mainFrame.getView_Configuration_ShowChecklistMenu().isEnabled()) {
+			errors.add("View->Configuration->Show Checklist menu is enabled when unexpected (TS selected, WD created, no config)");
+		}
+
+		mainFrame.getConfiguration().load(CONFIG_NAME, true);
+
+		if (!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled()) {
+			errors.add("Configure->Load Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+		}
+		if (!mainFrame.getConfigure_NewConfigurationMenu().isEnabled()) {
+			errors.add("Configure->New Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+		}
+		if (!mainFrame.getConfigure_EditConfigurationMenu().isEnabled()) {
+			errors.add("Configure->Edit Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+		}
+		if (!mainFrame.getConfigure_EditQuickSetMenu().isEnabled()) {
+			errors.add("Configure->Edit Quick Set menu is disabled when unexpected (TS selected, WD created, config loaded)");
+		}
+
+	}
+
+	@Override
+	public String getDescription() {
+		return "This test checks that all menu items are enabled/disabled when it is needed. ";
+	}
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu04.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu04.java
@@ -38,94 +38,94 @@ import static jthtest.menu.Menu.*;
 
 public class Menu04 extends Test {
 
-	@Override
-	public void testImpl() throws Exception {
-		mainFrame = new JTFrame(true);
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
 
-		if (mainFrame.getFile_CloseMenu().isEnabled()) {
-			errors.add("File->Close menu is enabled when unexpected (NewDesktop)");
-		}
+          if (mainFrame.getFile_CloseMenu().isEnabled()) {
+               errors.add("File->Close menu is enabled when unexpected (NewDesktop)");
+          }
 
-		mainFrame.openDefaultTestSuite();
+          mainFrame.openDefaultTestSuite();
 
-		if (!mainFrame.getFile_CloseMenu().isEnabled()) {
-			errors.add("File->Close menu is disabled when unexpected (TS selected, no WD, no config)");
-		}
+          if (!mainFrame.getFile_CloseMenu().isEnabled()) {
+               errors.add("File->Close menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
 
-		if (mainFrame.getConfigure_EditConfigurationMenu().isEnabled()) {
-			errors.add("Configure->Edit Configuration menu is enabled when unexpected (TS selected, no WD, no config)");
-		}
-		if (mainFrame.getConfigure_EditQuickSetMenu().isEnabled()) {
-			errors.add("Configure->Edit Quick Set menu is enabled when unexpected (TS selected, no WD, no config)");
-		}
-		if (mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled()) {
-			errors.add("Configure->Load Recent Configuration menu is enabled when unexpected (TS selected, no WD, no config)");
-		}
-		if (!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled()) {
-			errors.add("Configure->Load Configuration menu is disabled when unexpected (TS selected, no WD, no config)");
-		}
-		if (!mainFrame.getConfigure_NewConfigurationMenu().isEnabled()) {
-			errors.add("Configure->New Configuration menu is disabled when unexpected (TS selected, no WD, no config)");
-		}
+          if (mainFrame.getConfigure_EditConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Edit Configuration menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (mainFrame.getConfigure_EditQuickSetMenu().isEnabled()) {
+               errors.add("Configure->Edit Quick Set menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Load Recent Configuration menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Load Configuration menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (!mainFrame.getConfigure_NewConfigurationMenu().isEnabled()) {
+               errors.add("Configure->New Configuration menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
 
-		if (mainFrame.getReport_CreateReportMenu().isEnabled()) {
-			errors.add("Report->Create Report menu is enabled when unexpected (TS selected, no WD, no config)");
-		}
-		if (mainFrame.getReport_OpenReportMenu().isEnabled()) {
-			errors.add("Report->Open Report menu is enabled when unexpected (TS selected, no WD, no config)");
-		}
+          if (mainFrame.getReport_CreateReportMenu().isEnabled()) {
+               errors.add("Report->Create Report menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (mainFrame.getReport_OpenReportMenu().isEnabled()) {
+               errors.add("Report->Open Report menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
 
-		if (!mainFrame.getView_PropertiesMenu().isEnabled()) {
-			errors.add("View->Properties menu is disabled when unexpected (TS selected, no WD, no config)");
-		}
-		if (mainFrame.getView_LogsMenu().isEnabled()) {
-			errors.add("View->Logs menu is enabled when unexpected (TS selected, no WD, no config)");
-		}
-		if (!mainFrame.getView_Configuration_ShowChecklistMenu().isEnabled()) {
-			errors.add("View->Configuration->Show Checklist menu is disabled when unexpected (TS selected, no WD, no config)");
-		}
+          if (!mainFrame.getView_PropertiesMenu().isEnabled()) {
+               errors.add("View->Properties menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (mainFrame.getView_LogsMenu().isEnabled()) {
+               errors.add("View->Logs menu is enabled when unexpected (TS selected, no WD, no config)");
+          }
+          if (!mainFrame.getView_Configuration_ShowChecklistMenu().isEnabled()) {
+               errors.add("View->Configuration->Show Checklist menu is disabled when unexpected (TS selected, no WD, no config)");
+          }
 
-		addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
 
-		if (mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled()) {
-			errors.add("Configure->Load Recent Configuration menu is enabled when unexpected (TS selected, WD created, no config)");
-		}
+          if (mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Load Recent Configuration menu is enabled when unexpected (TS selected, WD created, no config)");
+          }
 
-		if (!mainFrame.getView_PropertiesMenu().isEnabled()) {
-			errors.add("View->Properties menu is disabled when unexpected (TS selected, WD created, no config)");
-		}
-		if (!mainFrame.getView_LogsMenu().isEnabled()) {
-			errors.add("View->Logs menu is disabled when unexpected (TS selected, WD created, no config)");
-		}
-		if (!mainFrame.getReport_CreateReportMenu().isEnabled()) {
-			errors.add("Report->Create Report menu is disabled when unexpected (TS selected, WD created, no config)");
-		}
-		if (!mainFrame.getReport_OpenReportMenu().isEnabled()) {
-			errors.add("Report->Open Report menu is disabled when unexpected (TS selected, WD created, no config)");
-		}
-		if (mainFrame.getView_Configuration_ShowChecklistMenu().isEnabled()) {
-			errors.add("View->Configuration->Show Checklist menu is enabled when unexpected (TS selected, WD created, no config)");
-		}
+          if (!mainFrame.getView_PropertiesMenu().isEnabled()) {
+               errors.add("View->Properties menu is disabled when unexpected (TS selected, WD created, no config)");
+          }
+          if (!mainFrame.getView_LogsMenu().isEnabled()) {
+               errors.add("View->Logs menu is disabled when unexpected (TS selected, WD created, no config)");
+          }
+          if (!mainFrame.getReport_CreateReportMenu().isEnabled()) {
+               errors.add("Report->Create Report menu is disabled when unexpected (TS selected, WD created, no config)");
+          }
+          if (!mainFrame.getReport_OpenReportMenu().isEnabled()) {
+               errors.add("Report->Open Report menu is disabled when unexpected (TS selected, WD created, no config)");
+          }
+          if (mainFrame.getView_Configuration_ShowChecklistMenu().isEnabled()) {
+               errors.add("View->Configuration->Show Checklist menu is enabled when unexpected (TS selected, WD created, no config)");
+          }
 
-		mainFrame.getConfiguration().load(CONFIG_NAME, true);
+          mainFrame.getConfiguration().load(CONFIG_NAME, true);
 
-		if (!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled()) {
-			errors.add("Configure->Load Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
-		}
-		if (!mainFrame.getConfigure_NewConfigurationMenu().isEnabled()) {
-			errors.add("Configure->New Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
-		}
-		if (!mainFrame.getConfigure_EditConfigurationMenu().isEnabled()) {
-			errors.add("Configure->Edit Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
-		}
-		if (!mainFrame.getConfigure_EditQuickSetMenu().isEnabled()) {
-			errors.add("Configure->Edit Quick Set menu is disabled when unexpected (TS selected, WD created, config loaded)");
-		}
+          if (!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Load Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+          }
+          if (!mainFrame.getConfigure_NewConfigurationMenu().isEnabled()) {
+               errors.add("Configure->New Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+          }
+          if (!mainFrame.getConfigure_EditConfigurationMenu().isEnabled()) {
+               errors.add("Configure->Edit Configuration menu is disabled when unexpected (TS selected, WD created, config loaded)");
+          }
+          if (!mainFrame.getConfigure_EditQuickSetMenu().isEnabled()) {
+               errors.add("Configure->Edit Quick Set menu is disabled when unexpected (TS selected, WD created, config loaded)");
+          }
 
-	}
+     }
 
-	@Override
-	public String getDescription() {
-		return "This test checks that all menu items are enabled/disabled when it is needed. ";
-	}
+     @Override
+     public String getDescription() {
+          return "This test checks that all menu items are enabled/disabled when it is needed. ";
+     }
 }

--- a/gui-tests/src/gui/src/jthtest/menu/Menu05.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu05.java
@@ -1,0 +1,88 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.menu;
+
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.JTFrame;
+
+public class Menu05 extends Test {
+
+    public Menu05() {
+        depricated = true; // ConfigDialog is now modal, no need to block menu items
+    }
+
+    @Override
+    public void testImpl() throws Exception {
+	mainFrame = JTFrame.startJTWithDefaultWorkDirectory();
+
+	if(!mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+	    errors.add("Configure->Edit Configuration menu is disabled before Configuration Editor is opened while unexpected");
+	if(!mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+	    errors.add("Configure->Edit Quick Set menu is disabled before Configuration Editor is opened while unexpected");
+	if(!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+	    errors.add("Configure->Load Configuration menu is disabled before Configuration Editor is opened while unexpected");
+	if(!mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+	    errors.add("Configure->Load Recent Configuration menu is disabled before Configuration Editor is opened while unexpected");
+	if(!mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+	    errors.add("Configure->New Configuration menu is disabled before Configuration Editor is opened while unexpected");
+
+	ConfigDialog cd = mainFrame.getConfiguration().openByMenu(true);
+
+	if(mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+	    errors.add("Configure->Edit Configuration menu is enabled while Configuration Editor is opened while unexpected");
+	if(mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+	    errors.add("Configure->Edit Quick Set menu is enabled while Configuration Editor is opened while unexpected");
+	if(mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+	    errors.add("Configure->Load Configuration menu is enabled while Configuration Editor is opened while unexpected");
+	if(mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+	    errors.add("Configure->Load Recent Configuration menu is enabled while Configuration Editor is opened while unexpected");
+	if(mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+	    errors.add("Configure->New Configuration menu is enabled while Configuration Editor is opened while unexpected");
+
+	cd.closeByMenu();
+
+	if(!mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+	    errors.add("Configure->Edit Configuration menu is disabled after Configuration Editor is opened while unexpected");
+	if(!mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+	    errors.add("Configure->Edit Quick Set menu is disabled after Configuration Editor is opened while unexpected");
+	if(!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+	    errors.add("Configure->Load Configuration menu is disabled after Configuration Editor is opened while unexpected");
+	if(!mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+	    errors.add("Configure->Load Recent Configuration menu is disabled after Configuration Editor is opened while unexpected");
+	if(!mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+	    errors.add("Configure->New Configuration menu is disabled after Configuration Editor is opened while unexpected");
+	
+    }
+
+    @Override
+    public String getDescription() {
+	return "This test checks that all Configure menu subelements are disabled when Configuration Editor is opened and are enabled after it's closing";
+    }
+
+}

--- a/gui-tests/src/gui/src/jthtest/menu/Menu05.java
+++ b/gui-tests/src/gui/src/jthtest/menu/Menu05.java
@@ -39,50 +39,50 @@ public class Menu05 extends Test {
 
     @Override
     public void testImpl() throws Exception {
-	mainFrame = JTFrame.startJTWithDefaultWorkDirectory();
+     mainFrame = JTFrame.startJTWithDefaultWorkDirectory();
 
-	if(!mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
-	    errors.add("Configure->Edit Configuration menu is disabled before Configuration Editor is opened while unexpected");
-	if(!mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
-	    errors.add("Configure->Edit Quick Set menu is disabled before Configuration Editor is opened while unexpected");
-	if(!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
-	    errors.add("Configure->Load Configuration menu is disabled before Configuration Editor is opened while unexpected");
-	if(!mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
-	    errors.add("Configure->Load Recent Configuration menu is disabled before Configuration Editor is opened while unexpected");
-	if(!mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
-	    errors.add("Configure->New Configuration menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+         errors.add("Configure->Edit Configuration menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+         errors.add("Configure->Edit Quick Set menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Configuration menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Recent Configuration menu is disabled before Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+         errors.add("Configure->New Configuration menu is disabled before Configuration Editor is opened while unexpected");
 
-	ConfigDialog cd = mainFrame.getConfiguration().openByMenu(true);
+     ConfigDialog cd = mainFrame.getConfiguration().openByMenu(true);
 
-	if(mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
-	    errors.add("Configure->Edit Configuration menu is enabled while Configuration Editor is opened while unexpected");
-	if(mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
-	    errors.add("Configure->Edit Quick Set menu is enabled while Configuration Editor is opened while unexpected");
-	if(mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
-	    errors.add("Configure->Load Configuration menu is enabled while Configuration Editor is opened while unexpected");
-	if(mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
-	    errors.add("Configure->Load Recent Configuration menu is enabled while Configuration Editor is opened while unexpected");
-	if(mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
-	    errors.add("Configure->New Configuration menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+         errors.add("Configure->Edit Configuration menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+         errors.add("Configure->Edit Quick Set menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Configuration menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Recent Configuration menu is enabled while Configuration Editor is opened while unexpected");
+     if(mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+         errors.add("Configure->New Configuration menu is enabled while Configuration Editor is opened while unexpected");
 
-	cd.closeByMenu();
+     cd.closeByMenu();
 
-	if(!mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
-	    errors.add("Configure->Edit Configuration menu is disabled after Configuration Editor is opened while unexpected");
-	if(!mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
-	    errors.add("Configure->Edit Quick Set menu is disabled after Configuration Editor is opened while unexpected");
-	if(!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
-	    errors.add("Configure->Load Configuration menu is disabled after Configuration Editor is opened while unexpected");
-	if(!mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
-	    errors.add("Configure->Load Recent Configuration menu is disabled after Configuration Editor is opened while unexpected");
-	if(!mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
-	    errors.add("Configure->New Configuration menu is disabled after Configuration Editor is opened while unexpected");
-	
+     if(!mainFrame.getConfigure_EditConfigurationMenu().isEnabled())
+         errors.add("Configure->Edit Configuration menu is disabled after Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_EditQuickSetMenu().isEnabled())
+         errors.add("Configure->Edit Quick Set menu is disabled after Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_LoadConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Configuration menu is disabled after Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_LoadRecentConfigurationMenu().isEnabled())
+         errors.add("Configure->Load Recent Configuration menu is disabled after Configuration Editor is opened while unexpected");
+     if(!mainFrame.getConfigure_NewConfigurationMenu().isEnabled())
+         errors.add("Configure->New Configuration menu is disabled after Configuration Editor is opened while unexpected");
+
     }
 
     @Override
     public String getDescription() {
-	return "This test checks that all Configure menu subelements are disabled when Configuration Editor is opened and are enabled after it's closing";
+     return "This test checks that all Configure menu subelements are disabled when Configuration Editor is opened and are enabled after it's closing";
     }
 
 }


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. Menu01.java
2. Menu02.java
3. Menu03.java
4. Menu04.java
5. Menu05.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903701](https://bugs.openjdk.org/browse/CODETOOLS-7903701): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jtharness.git pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/65.diff">https://git.openjdk.org/jtharness/pull/65.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/65#issuecomment-2022896080)