### PR TITLE
7903705: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate4.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate4.java
@@ -1,0 +1,64 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import jthtest.Test;
+import static jthtest.ReportCreate.ReportCreate.*;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate4 extends Test {
+    /**
+     * This test case verifies that de-selecting the number for selecting the
+     * backups of old reports checkbox will not create any back up of the report.
+     */
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        String path = TEMP_PATH + "new" + File.separator + "directory";
+        File file = new File(path);
+        deleteDirectory(file);
+
+        setPath(rep, path);
+
+        pressCreate(rep);
+        addUsedFile(file);
+
+        if (!file.exists()) {
+            throw new JemmyException("directory " + path + " was not created");
+        } else {
+            deleteDirectory(file);
+        }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate5.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate5.java
@@ -1,0 +1,66 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/* Start JavaTest with an existing workdirectory. Bring up Create Report from
+ * the Report menu. Enter a /foo/bar/report path for report directory name.
+ * Click on Create Reports button. An error message should be displayed. Verify
+ * that an error message is displayed indicating cannot write reports:
+ * /foo/bar/report/report.html(No such file or directory)
+ */
+package jthtest.ReportCreate;
+
+import jthtest.Test;
+import static jthtest.ReportCreate.ReportCreate.*;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate5 extends Test {
+    /**
+     * This test case verifies that Create Report button under Report menu will
+     * produce an error message for if a non-existing path is specified for a report
+     * directory name.
+     */
+    public ReportCreate5() {
+        knownFail = true; // fails on Windows platform
+    }
+
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        String path = "/broken/path!@#$%^&";
+
+        setPath(rep, path);
+
+        pressCreate(rep);
+
+        new JDialogOperator(WINDOWNAME + " Harness: Error");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate6.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate6.java
@@ -1,0 +1,59 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.lang.reflect.InvocationTargetException;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate6 extends ReportCreate {
+    /**
+     * This test case verifies that Help button in the Create Report Directory
+     * dialog box works properly.
+     */
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.ReportCreate.ReportCreate6");
+    }
+
+    @Test
+    public void testReportCreate6() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        new JButtonOperator(rep, "Help").push();
+
+        new JButtonOperator(rep, "Cancel").push();
+
+        // new JFrameOperator(WINDOWNAME + " Harness User's Guide");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate8.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate8.java
@@ -1,0 +1,66 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.io.File;
+import jthtest.Test;
+import static jthtest.ReportCreate.ReportCreate.*;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate8 extends Test {
+
+    public void testImpl() throws Exception {
+        deleteUserData();
+        startJavaTestWithDefaultWorkDirectory();
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+        setPlainChecked(rep, false);
+        setXmlChecked(rep, false);
+        String path = TEMP_PATH + REPORT_NAME + REPORT_POSTFIX_HTML + File.separator;
+        File f = new File(path);
+        deleteDirectory(f);
+
+        setPath(rep, path);
+
+        HtmlReport html = new HtmlReport(rep);
+        html.setFilesAll(false);
+        html.setFilesPutInReport(true);
+        html.setOptionsAll(false);
+        html.setOptionsConfiguration(true, true, false, false);
+
+        pressCreate(rep);
+        addUsedFile(f);
+
+        pressYes(findShowReportDialog());
+
+        new HtmlReportChecker(path, html).commitMainCheck();
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate9.java
+++ b/gui-tests/src/gui/src/jthtest/ReportCreate/ReportCreate9.java
@@ -1,0 +1,53 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportCreate;
+
+import java.lang.reflect.InvocationTargetException;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class ReportCreate9 extends ReportCreate {
+
+    public static void main(String[] args) {
+        JUnitCore.main("jthtest.gui.ReportCreate.ReportCreate9");
+    }
+
+    @Test
+    public void testReportCreate9() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+        startJavaTestWithDefaultWorkDirectory();
+
+        String path = "/badpath";
+
+        JFrameOperator mainFrame = findMainFrame();
+
+        JDialogOperator rep = openReportCreation(mainFrame);
+
+
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. ReportCreate4.java
2. ReportCreate5.java
3. ReportCreate6.java
4. ReportCreate8.java
5. ReportCreate9.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903705](https://bugs.openjdk.org/browse/CODETOOLS-7903705): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/jtharness.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/66.diff">https://git.openjdk.org/jtharness/pull/66.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/66#issuecomment-2034242586)