### PR TITLE
7903713: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir02.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir02.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import java.io.File;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.Test;
+
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir02 extends Test {
+
+     public CreateWorkdir02() {
+          depricated = true;
+     }
+
+     public void testImpl() throws Exception {
+
+          /**
+           * This test case verifies that a path for saving a workdirectory is seeded with
+           * the default while creating a workdirectory.
+           */
+          deleteDirectory(DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME);
+
+          JTFrame mainFrame = JTFrame.startJTWithDefaultTestSuite();
+
+          File created = mainFrame.getWorkDirectory().createWorkDirectory(TO_DELETE_TEMP_WD_NAME, true);
+          addUsedFile(created);
+
+          if (!created.exists()) {
+               errors.add("Work directory wasn't created propertly with path " + DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME);
+          }
+
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir02.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir02.java
@@ -38,6 +38,10 @@ import static jthtest.workdir.Workdir.*;
 
 public class CreateWorkdir02 extends Test {
 
+     public CreateWorkdir02() {
+          depricated = true;
+     }
+
      public void testImpl() throws Exception {
 
           /**

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir02.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir02.java
@@ -38,10 +38,6 @@ import static jthtest.workdir.Workdir.*;
 
 public class CreateWorkdir02 extends Test {
 
-     public CreateWorkdir02() {
-          depricated = true;
-     }
-
      public void testImpl() throws Exception {
 
           /**

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir04.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir04.java
@@ -1,0 +1,76 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import java.io.File;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.Test;
+
+import jthtest.Tools;
+import org.netbeans.jemmy.TimeoutExpiredException;
+import org.netbeans.jemmy.operators.JTextComponentOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir04 extends Test {
+    /*
+     * There should be a warning-message when trying to create inexisting path
+     */
+
+    public void testImpl() throws Exception {
+     startJavaTestWithDefaultTestSuite();
+
+     JFrameOperator mainFrame = findMainFrame();
+
+     deleteDirectory(TEMP_PATH + "bad_dir");
+     createWorkDirectory(TEMP_PATH + "bad_dir" + File.separator + TEMP_WD_NAME, false, mainFrame);
+     File f = new File(TEMP_PATH + "bad_dir" + File.separator + TEMP_WD_NAME);
+     addUsedFile(f);
+
+     try {
+         new JTextComponentOperator(mainFrame, TEMP_WD_NAME);
+     } catch(TimeoutExpiredException e) {
+         errors.add("Component with WD name was not found");
+     }
+     if (!f.exists()) {
+         errors.add("Work Directory was not created properly");
+     }
+     if (!mainFrame.getTitle().endsWith(f.getAbsolutePath())) {
+         errors.add("Title has not new WD path (" + f.getAbsolutePath() + "), title: " + mainFrame.getTitle());
+     }
+    }
+
+    @Override
+    public String getDescription() {
+     return "WD directory should be created recursively";
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir05.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir05.java
@@ -1,0 +1,71 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import jthtest.workdir.*;
+import java.io.File;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+
+public class CreateWorkdir05 extends Test {
+
+     /**
+      * This test case verifies that a path for saving a workdirectory is seeded with
+      * the default while creating a workdirectory.
+      */
+    JFrameOperator mainFrame;
+
+    public void testImpl() throws Exception {
+     startJavaTestWithDefaultTestSuite();
+
+     mainFrame = findMainFrame();
+
+     deleteDirectory(TEMP_PATH + TEMP_WD_NAME);
+     Workdir.createWorkDirectory(TEMP_PATH + TEMP_WD_NAME, true, mainFrame);
+     addUsedFile(TEMP_PATH + TEMP_WD_NAME);
+
+     if (new File(TEMP_PATH + TEMP_WD_NAME + File.separator + "jtData" + File.separator + "template.data").exists()) {
+         throw new JemmyException("Found template config in workdir while not expected");
+     }
+
+     if (new JTextFieldOperator(mainFrame, new NameComponentChooser("bcc.Configuration")).getText().equals("demotemplate.jtm")) {
+         throw new JemmyException("Template is opened while not expected");
+     }
+
+     if (new JMenuOperator(mainFrame, getExecResource("ch.menu")).getMenuComponent(1).isEnabled()) {
+         throw new JemmyException("Template editing found while not expected");
+     }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java
@@ -41,6 +41,10 @@ public class CreateWorkdir06 extends Test {
 
      JFrameOperator mainFrame;
 
+     public CreateWorkdir02() {
+     depricated = true;
+     }
+
      public void testImpl() throws Exception {
           startJavaTestWithDefaultTestSuite();
           mainFrame = findMainFrame();

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java
@@ -1,0 +1,70 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Test;
+import jthtest.ConfigTools;
+
+import static jthtest.workdir.Workdir.*;
+import static jthtest.Tools.*;
+
+public class CreateWorkdir06 extends Test {
+
+     JFrameOperator mainFrame;
+
+     public CreateWorkdir06() {
+          depricated = true;
+     }
+
+     public void testImpl() throws Exception {
+          startJavaTestWithDefaultTestSuite();
+          mainFrame = findMainFrame();
+
+          deleteDirectory(DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME);
+          createWorkDirectory(TEMP_PATH + TO_DELETE_TEMP_WD_NAME, true, mainFrame);
+          addUsedFile(DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME);
+          ConfigTools.openConfigFile(ConfigTools.openLoadConfigDialogByMenu(mainFrame), TEMPLATE_NAME);
+
+          if (!(new JTextFieldOperator(mainFrame, new NameComponentChooser("bcc.WorkDir")).getText()
+                    .equals(TO_DELETE_TEMP_WD_NAME))) {
+               throw new JemmyException("Work Directory is not shown in status bar");
+          }
+          if (!(new JTextFieldOperator(mainFrame, new NameComponentChooser("bcc.Configuration")).getText()
+                    .equals(TEMPLATE_NAME))) {
+               throw new JemmyException("Template is not shown in status bar");
+          }
+          if (!verifyWorkdirCreation(TEMP_PATH + TO_DELETE_TEMP_WD_NAME)) {
+               throw new JemmyException(
+                         "Work directory wasn't created propertly with path " + TEMP_PATH + TO_DELETE_TEMP_WD_NAME);
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java
@@ -41,10 +41,6 @@ public class CreateWorkdir06 extends Test {
 
      JFrameOperator mainFrame;
 
-     public CreateWorkdir06() {
-          depricated = true;
-     }
-
      public void testImpl() throws Exception {
           startJavaTestWithDefaultTestSuite();
           mainFrame = findMainFrame();

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir07.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir07.java
@@ -39,10 +39,6 @@ import static jthtest.workdir.Workdir.*;
 
 public class CreateWorkdir07 extends Test {
 
-     public CreateWorkdir07() {
-          depricated = true;
-     }
-
      public void testImpl() throws Exception {
 
           startJavaTestWithDefaultTestSuite();

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir07.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir07.java
@@ -39,6 +39,10 @@ import static jthtest.workdir.Workdir.*;
 
 public class CreateWorkdir07 extends Test {
 
+     public CreateWorkdir07() {
+     depricated = true;
+     }
+
      public void testImpl() throws Exception {
 
           startJavaTestWithDefaultTestSuite();

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir07.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir07.java
@@ -1,0 +1,72 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.ConfigTools;
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir07 extends Test {
+
+     public CreateWorkdir07() {
+          depricated = true;
+     }
+
+     public void testImpl() throws Exception {
+
+          startJavaTestWithDefaultTestSuite();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          deleteDirectory(DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME);
+          createWorkDirectory(TO_DELETE_TEMP_WD_NAME, true, mainFrame);
+          addUsedFile(DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME);
+          ConfigTools.openConfigFile(ConfigTools.openLoadConfigDialogByMenu(mainFrame), TEMPLATE_NAME);
+
+          if (!(new JTextFieldOperator(mainFrame, new NameComponentChooser("bcc.WorkDir")).getText()
+                    .equals(TO_DELETE_TEMP_WD_NAME))) {
+               throw new JemmyException("Work Directory is not shown in status bar");
+          }
+
+          if (!(new JTextFieldOperator(mainFrame, new NameComponentChooser("bcc.Configuration")).getText()
+                    .equals(TEMPLATE_NAME))) {
+               throw new JemmyException("Template is not shown in status bar");
+          }
+
+          if (!verifyWorkdirCreation(DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME)) {
+               throw new JemmyException(
+                         "Work directory wasn't created propertly with path " + DEFAULT_PATH + TO_DELETE_TEMP_WD_NAME);
+          }
+     }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. CreateWorkdir2.java
2. CreateWorkdir4.java
3. CreateWorkdir5.java
4. CreateWorkdir6.java
5. CreateWorkdir7.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903713](https://bugs.openjdk.org/browse/CODETOOLS-7903713): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jtharness.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/68.diff">https://git.openjdk.org/jtharness/pull/68.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/68#issuecomment-2060996677)