### PR TITLE
7903714: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir08.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir08.java
@@ -62,7 +62,7 @@ public class CreateWorkdir08 extends Test {
 
           JTextField templatePath = (JTextField) (new JLabelOperator(wrkDir, getExecResource("wdc.template.path.lbl"))
                     .getLabelFor());
-	  if (templatePath.getText().equals("")) {
+       if (templatePath.getText().equals("")) {
                throw new JemmyException("Default template path is empty!");
           }else if (!((templatePath.getText() + File.separator).equals(DEFAULT_PATH))) {
                throw new JemmyException("Default template path doesn't match default path: " + templatePath.getText()

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir08.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir08.java
@@ -1,0 +1,75 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.CreateWorkdir;
+
+import java.io.File;
+import javax.swing.JTextField;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JLabelOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+/**
+ *
+ * @author linfar
+ */
+public class CreateWorkdir08 extends Test {
+
+     public CreateWorkdir08() {
+          depricated = true;
+     }
+
+     public void testImpl() throws Exception {
+          startJavaTestWithDefaultTestSuite();
+
+          String path;
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          deleteDirectory(DEFAULT_PATH + TEMP_WD_NAME);
+          JDialogOperator wrkDir = openCreateWorkDirectoryDialog(mainFrame);
+          chooseWorkDirectoryInDialog(wrkDir, TEMP_WD_NAME);
+
+          new JRadioButtonOperator(wrkDir, getExecResource("wdc.template.rb")).push();
+
+          JTextField templatePath = (JTextField) (new JLabelOperator(wrkDir, getExecResource("wdc.template.path.lbl"))
+                    .getLabelFor());
+          if (templatePath.getText().equals(""))
+               throw new JemmyException("Default template path is empty!");
+          if (!((templatePath.getText() + File.separator).equals(DEFAULT_PATH)))
+               throw new JemmyException("Default template path doesn't match default path: " + templatePath.getText()
+                         + File.separator + " != " + DEFAULT_PATH);
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir08.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir08.java
@@ -41,10 +41,6 @@ import jthtest.Test;
 import static jthtest.Tools.*;
 import static jthtest.workdir.Workdir.*;
 
-/**
- *
- * @author linfar
- */
 public class CreateWorkdir08 extends Test {
 
      public CreateWorkdir08() {

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir08.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir08.java
@@ -62,10 +62,11 @@ public class CreateWorkdir08 extends Test {
 
           JTextField templatePath = (JTextField) (new JLabelOperator(wrkDir, getExecResource("wdc.template.path.lbl"))
                     .getLabelFor());
-          if (templatePath.getText().equals(""))
+	  if (templatePath.getText().equals("")) {
                throw new JemmyException("Default template path is empty!");
-          if (!((templatePath.getText() + File.separator).equals(DEFAULT_PATH)))
+          }else if (!((templatePath.getText() + File.separator).equals(DEFAULT_PATH))) {
                throw new JemmyException("Default template path doesn't match default path: " + templatePath.getText()
                          + File.separator + " != " + DEFAULT_PATH);
+          }
      }
 }

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir09.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir09.java
@@ -1,0 +1,54 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.ConfigTools;
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir09 extends Test {
+
+    public CreateWorkdir09() {
+     depricated = true;
+    }
+
+    public void testImpl() throws Exception {
+     startJavaTestWithDefaultTestSuite();
+     JFrameOperator mainFrame = findMainFrame();
+
+     createWorkDirectory(TO_DELETE_TEMP_WD_NAME, true, mainFrame);
+     addUsedFile(TO_DELETE_TEMP_WD_NAME);
+     ConfigTools.openConfigFile(ConfigTools.openLoadConfigDialogByMenu(mainFrame), "demotemplate_brokenchecksum.jtm");
+
+     new JDialogOperator(mainFrame, WINDOWNAME + " Harness: Error");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir11.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir11.java
@@ -1,0 +1,91 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import javax.swing.JTextField;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+
+public class CreateWorkdir11 extends Test {
+
+    public CreateWorkdir11() {
+     depricated = true;
+    }
+    private JFrameOperator mainFrame;
+
+    public void testImpl() throws Exception {
+     startJavaTestWithDefaultTestSuite();
+
+     mainFrame = findMainFrame();
+
+     // using especial function as a "Create" button must be inactive
+     createWorkDirWithBadTemplate();
+    }
+
+    private void createWorkDirWithBadTemplate() {
+     new JMenuOperator(mainFrame).pushMenuNoBlock(getExecResource("qlb.file.menu") + "|" + getExecResource("mgr.newWorkDir.act"), "|");
+
+     JDialogOperator wrkDir = new JDialogOperator(mainFrame, getToolResource("wdc.new.title"));
+
+     deleteDirectory(TEMP_PATH + TEMP_WD_NAME);
+
+     getTextField(wrkDir, getExecResource("wdc.dir.name.lbl")).typeText(TEMP_WD_NAME);
+
+     new JButtonOperator(wrkDir, getExecResource("wdc.browse.btn")).push();
+
+     JDialogOperator filer = new JDialogOperator(mainFrame, getExecResource("wdc.filechoosertitle"));
+
+     JTextFieldOperator tf;
+
+     tf = new JTextFieldOperator((JTextField) getComponent(filer, new String[]{"Folder name:", "File name:"}));
+     tf.enterText(TEMP_PATH);
+
+     new JRadioButtonOperator(wrkDir, getExecResource("wdc.template.rb")).push();
+
+     new JButtonOperator(wrkDir, new NameComponentChooser("wdc.template.browse")).push();
+
+     filer = new JDialogOperator(mainFrame, getExecResource("wdc.templchoosertitle"));
+
+     tf = new JTextFieldOperator((JTextField) getComponent(filer, new String[]{"Folder name:", "File name:"}));
+     tf.enterText("/brokenpath/");
+
+     if (new JButtonOperator(wrkDir, getExecResource("wdc.create.btn")).isEnabled()) {
+         throw new JemmyException("Create button is available while template path is broken");
+     }
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir13.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir13.java
@@ -1,0 +1,55 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.Test;
+import jthtest.ConfigTools;
+
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir13 extends Test {
+
+    public CreateWorkdir13() {
+     depricated = true;
+    }
+
+    public void testImpl() throws Exception {
+     startJavaTestWithDefaultTestSuite();
+
+     JFrameOperator mainFrame = findMainFrame();
+
+     createWorkDirectory(TEMP_PATH + TEMP_WD_NAME, true, mainFrame);
+     addUsedFile(TEMP_PATH + TEMP_WD_NAME);
+     ConfigTools.openConfigFile(ConfigTools.openLoadConfigDialogByMenu(mainFrame), TEMPLATE_NAME);
+
+     new JDialogOperator(mainFrame, getExecResource("ep.ce.title"));
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir15.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir15.java
@@ -54,7 +54,7 @@ public class CreateWorkdir15 extends Test {
 
      JComboBoxOperator cbOperator = new JComboBoxOperator(wdCreate);
 
-     if (!(new JComboBoxOperator(wdCreate).getSelectedItem() + File.separator).equals(LOCAL_PATH)) { 
+     if (!(new JComboBoxOperator(wdCreate).getSelectedItem() + File.separator).equals(LOCAL_PATH)) {
         throw new JemmyException("Default work directory doesn't match directory from which JavaTest was opened");
      }
     }

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir15.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir15.java
@@ -54,8 +54,8 @@ public class CreateWorkdir15 extends Test {
 
      JComboBoxOperator cbOperator = new JComboBoxOperator(wdCreate);
 
-     if (!((new JComboBoxOperator(wdCreate).getSelectedItem() + File.separator).equals(LOCAL_PATH))) {
-         throw new JemmyException("Default work directory doesn't match directory from which JavaTest was opened");
+     if (!(new JComboBoxOperator(wdCreate).getSelectedItem() + File.separator).equals(LOCAL_PATH)) { 
+        throw new JemmyException("Default work directory doesn't match directory from which JavaTest was opened");
      }
     }
 }

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir15.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir15.java
@@ -1,0 +1,61 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import java.io.File;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JComboBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir15 extends Test {
+
+    public CreateWorkdir15() {
+     depricated = true;
+    }
+
+    public void testImpl() throws Exception {
+     startJavatestNewDesktop();
+
+     JFrameOperator mainFrame = findMainFrame();
+     openTestSuite(mainFrame);
+
+     JDialogOperator wdCreate = openOpenWorkDirectoryDialog(mainFrame);
+
+     JComboBoxOperator cbOperator = new JComboBoxOperator(wdCreate);
+
+     if (!((new JComboBoxOperator(wdCreate).getSelectedItem() + File.separator).equals(LOCAL_PATH))) {
+         throw new JemmyException("Default work directory doesn't match directory from which JavaTest was opened");
+     }
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. CreateWorkdir08.java
2. CreateWorkdir09.java
3. CreateWorkdir11.java
4. CreateWorkdir13.java
5. CreateWorkdir15.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903714](https://bugs.openjdk.org/browse/CODETOOLS-7903714): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jtharness.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/69.diff">https://git.openjdk.org/jtharness/pull/69.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/69#issuecomment-2061063736)