### PR TITLE
7903717: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit2.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit2.java
@@ -1,0 +1,92 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Edit;
+
+import java.util.Hashtable;
+import java.util.Iterator;
+import jthtest.Test;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JTableOperator;
+
+public class Config_Edit2 extends Test {
+     private final static Hashtable standartTable;
+
+     public Config_Edit2() {
+          depricated = true;
+     }
+
+     static {
+          standartTable = new Hashtable();
+          standartTable.put("Cell_5_1", "false");
+          standartTable.put("Cell_5_0", "val6");
+          standartTable.put("Cell_7_1", "drinkme");
+          standartTable.put("Cell_7_0", "unclassified");
+          standartTable.put("Cell_0_1", "foo");
+          standartTable.put("Cell_0_0", "value1");
+          standartTable.put("Cell_2_1", "65000");
+          standartTable.put("Cell_2_0", "colors");
+          standartTable.put("Cell_4_1", "/tmp/foo");
+          standartTable.put("Cell_4_0", "value5");
+          standartTable.put("Cell_6_1", "yEs");
+          standartTable.put("Cell_6_0", "val7");
+          standartTable.put("Cell_1_1", "1050");
+          standartTable.put("Cell_1_0", "port");
+          standartTable.put("Cell_3_1", "baz");
+          standartTable.put("Cell_3_0", "val4");
+     }
+
+     public void testImpl() throws Exception {
+//     startJavatestNewDesktop();
+//
+//     JFrameOperator mainFrame = findMainFrame();
+//
+//     closeQS(mainFrame);
+//
+//     CreateWorkdir.createWorkDir(CreateWorkdir.openWorkDirectoryOpening(mainFrame), LOCAL_PATH, WD_RUN, false);
+//
+//     new JTextFieldOperator(mainFrame, getExecResource("br.worst.1"));
+//     openConfigDialogByKey(mainFrame);
+//     checkAnswers(findConfigEditor(mainFrame));
+     }
+
+     private void checkAnswers(JDialogOperator config) {
+          JListOperator list = new JListOperator(config);
+          list.setSelectedIndex(7);
+
+          Hashtable table = new JTableOperator(config).getDump();
+          Iterator iter = standartTable.keySet().iterator();
+          while (iter.hasNext()) {
+               Object key = iter.next();
+               if (!table.containsKey(key) || !table.containsValue(standartTable.get(key)))
+                    throw new JemmyException("Element " + key + "=" + standartTable.get(key)
+                              + " was not found in table 'Capability settings'");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit2.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Edit/Config_Edit2.java
@@ -27,23 +27,28 @@
 
 package jthtest.Config_Edit;
 
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import jthtest.Test;
+import jthtest.CreateWorkdir.CreateWorkdir;
+
 import org.netbeans.jemmy.JemmyException;
 import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JListOperator;
 import org.netbeans.jemmy.operators.JTableOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
 
 public class Config_Edit2 extends Test {
-     private final static Hashtable standartTable;
+     private final static HashMap<String, String> standartTable;
 
      public Config_Edit2() {
           depricated = true;
      }
 
      static {
-          standartTable = new Hashtable();
+          standartTable = new HashMap<String, String>();
           standartTable.put("Cell_5_1", "false");
           standartTable.put("Cell_5_0", "val6");
           standartTable.put("Cell_7_1", "drinkme");
@@ -63,17 +68,17 @@ public class Config_Edit2 extends Test {
      }
 
      public void testImpl() throws Exception {
-//     startJavatestNewDesktop();
-//
-//     JFrameOperator mainFrame = findMainFrame();
-//
-//     closeQS(mainFrame);
-//
-//     CreateWorkdir.createWorkDir(CreateWorkdir.openWorkDirectoryOpening(mainFrame), LOCAL_PATH, WD_RUN, false);
-//
-//     new JTextFieldOperator(mainFrame, getExecResource("br.worst.1"));
-//     openConfigDialogByKey(mainFrame);
-//     checkAnswers(findConfigEditor(mainFrame));
+          Config_Edit.startJavatestNewDesktop();
+
+          JFrameOperator mainFrame = Config_Edit.findMainFrame();
+
+          Config_Edit.closeQS(mainFrame);
+
+          CreateWorkdir.createWorkDir(CreateWorkdir.openWorkDirectoryOpening(mainFrame), LOCAL_PATH, null, false);
+
+          new JTextFieldOperator(mainFrame, Config_Edit.getExecResource("br.worst.1"));
+          Config_Edit.openConfigDialogByKey(mainFrame);
+          checkAnswers(Config_Edit.findConfigEditor(mainFrame));
      }
 
      private void checkAnswers(JDialogOperator config) {
@@ -90,3 +95,4 @@ public class Config_Edit2 extends Test {
           }
      }
 }
+

--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load06_1.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load06_1.java
@@ -1,0 +1,77 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.Config_Load;
+
+import jthtest.ConfigTools;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+import org.netbeans.jemmy.operators.JMenuItemOperator;
+
+public class Config_Load06_1 extends Test {
+
+     public void testImpl() throws Exception {
+          JTFrame mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+          Configuration configuration = mainFrame.getConfiguration();
+          configuration.load(Tools.CONFIG_NAME, true);
+          configuration.load(ConfigTools.SECOND_CONFIG_NAME, true);
+          checkMenu(configuration.openByKey());
+     }
+
+     private void checkMenu(ConfigDialog config) {
+          JMenuItemOperator item = config.getFile_LoadRecentConfigurationMenu();
+          if (!item.isEnabled()) {
+               errors.add("Configuration Dialog: File -> Load Recent Configuration menu is not enabled while expected");
+               return;
+          }
+          JMenuItemOperator[] elements = config.getFile_LoadRecentConfiguration_subMenu();
+          if (elements.length != 2) {
+               errors.add("Count of elements is " + elements.length + " while expected 2");
+          }
+          if (elements.length > 0) {
+               if (!elements[0].getText().endsWith(ConfigTools.SECOND_CONFIG_NAME)) {
+                    errors.add("First element in the list is not 'democonfig_second.jti'");
+               }
+          }
+          if (elements.length > 1) {
+               if (!elements[1].getText().endsWith(ConfigTools.CONFIG_NAME)) {
+                    errors.add("Second element in the list is not 'democonfig.jti'");
+               }
+          }
+     }
+
+     @Override
+     public String getDescription() {
+          return "This test loads 2 different configuration files and checks that File -> Recent Configuration menu in Configuration Editor dialog contains both of them";
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load8.java
+++ b/gui-tests/src/gui/src/jthtest/Config_Load/Config_Load8.java
@@ -1,0 +1,55 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.Config_Load;
+
+import java.lang.reflect.InvocationTargetException;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JFrameOperator;
+
+public class Config_Load8 extends Config_Load {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.Config_Load.Config_Load8");
+     }
+
+     @Test
+     public void testConfig_Load8() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+          startJavatestNewDesktop();
+
+          JFrameOperator mainFrame = findMainFrame();
+
+          closeQS(mainFrame);
+
+          openTestSuite(mainFrame);
+
+          createWorkDirInTemp(mainFrame);
+
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), "democonfig with spaces.jti");
+          openConfigDialogByKey(mainFrame);
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir16.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir16.java
@@ -1,0 +1,70 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.CreateWorkdir;
+
+import java.io.File;
+import javax.swing.JTextField;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JLabelOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+import static jthtest.workdir.Workdir.*;
+
+public class CreateWorkdir16 extends Test {
+
+     public CreateWorkdir16() {
+          depricated = true;
+     }
+
+     public void testImpl() throws Exception {
+          startJavaTestWithDefaultTestSuite();
+
+          JFrameOperator mainFrame = findMainFrame();
+          JDialogOperator wdCreate = openOpenWorkDirectoryDialog(mainFrame);
+
+          new JButtonOperator(wdCreate, getExecResource("wdc.browse.btn")).push();
+          JDialogOperator filer = new JDialogOperator(mainFrame, getExecResource("wdc.filechoosertitle"));
+
+          JTextFieldOperator tf;
+
+          tf = new JTextFieldOperator((JTextField) getComponent(filer, new String[] { "Folder name:", "File name:" }));
+          tf.enterText(TEMP_PATH);
+
+          JTextField browsePath = (JTextField) (new JLabelOperator(wdCreate, getExecResource("wdc.dir.path.lbl"))
+                    .getLabelFor());
+          if (!(browsePath.getText() + File.separator).equals(TEMP_PATH))
+               throw new JemmyException("Browsing works not correctly");
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir17.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir17.java
@@ -1,0 +1,61 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.CreateWorkdir;
+
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Test;
+
+import static jthtest.Tools.*;
+
+public class CreateWorkdir17 extends Test {
+
+     public CreateWorkdir17() {
+          depricated = true;
+     }
+
+     JFrameOperator mainFrame;
+
+     public void testImpl() throws Exception {
+          startJavatest(new String[] { "-workdir", "demowd_template" });
+
+          mainFrame = findMainFrame();
+
+          if (!(new JTextFieldOperator(mainFrame, new NameComponentChooser("bcc.WorkDir")).getText()
+                    .equals("demowd_template"))) {
+               throw new JemmyException("Work Directory is not shown in status bar");
+          }
+          if (!(new JTextFieldOperator(mainFrame, new NameComponentChooser("bcc.Configuration")).getText()
+                    .equals("demotemplate.jtm"))) {
+               throw new JemmyException("Template is not shown in status bar");
+          }
+     }
+
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. CreateWorkdir16.java
2. CreateWorkdir17.java
3. Config_Edit2.java
4. Config_Load6_1.java
5. Config_Load8.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903717](https://bugs.openjdk.org/browse/CODETOOLS-7903717): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/jtharness.git pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/70.diff">https://git.openjdk.org/jtharness/pull/70.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/70#issuecomment-2068930815)