### PR TITLE
7903718: Feature Tests - Adding four JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/Markers/Markers22.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers22.java
@@ -24,13 +24,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
- * Start JavaTest with the -NewDesktop option. Create a workdirectory. Load an
- * existing JTI file. Bring up configuration editor by doing Ctrl-E. Select the
- * Enable Bookmarks from the Bookmarks menu. Select couple of questions from
- * the history list. Bring up the popup menu and mark the all the questions.
- * Bring up the Clear Answers to Marked Questions from the Bookmarks menu.
- * Verify that all the selected questions should be have empty answers.
+ * This test case verifies that selecting the remove all marked questions button will remove the marked question.
  */
 package jthtest.Markers;
 

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers22.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers22.java
@@ -106,9 +106,4 @@ public class Markers22 extends Test {
           new JTextFieldOperator(config, new NameComponentChooser("flt.field.txt")).setText("");
           new JTextFieldOperator(config, new NameComponentChooser("flt.field.txt")).typeText("22");
      }
-
-     @Override
-     public String getDescription() {
-          return "Start JavaTest with the -NewDesktop option. Create a workdirectory. Load an existing JTI file. Bring up configuration editor by doing Ctrl-E. Select the Enable Bookmarks from the Bookmarks menu. Select couple of questions from the history list. Bring up the popup menu and mark the all the questions. Bring up the Clear Answers to Marked Questions from the Bookmarks menu. Verify that all the selected questions should be have empty answers.";
-     }
 }

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers22.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers22.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,6 @@
  * questions.
  */
 
-/*
- * This test case verifies that selecting the remove all marked questions button will remove the marked question.
- */
 package jthtest.Markers;
 
 import java.lang.reflect.InvocationTargetException;

--- a/gui-tests/src/gui/src/jthtest/Markers/Markers22.java
+++ b/gui-tests/src/gui/src/jthtest/Markers/Markers22.java
@@ -1,0 +1,114 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * Start JavaTest with the -NewDesktop option. Create a workdirectory. Load an
+ * existing JTI file. Bring up configuration editor by doing Ctrl-E. Select the
+ * Enable Bookmarks from the Bookmarks menu. Select couple of questions from
+ * the history list. Bring up the popup menu and mark the all the questions.
+ * Bring up the Clear Answers to Marked Questions from the Bookmarks menu.
+ * Verify that all the selected questions should be have empty answers.
+ */
+package jthtest.Markers;
+
+import java.lang.reflect.InvocationTargetException;
+import jthtest.Test;
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import jthtest.tools.JTFrame;
+import org.netbeans.jemmy.JemmyException;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JListOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class Markers22 extends Test {
+
+     /**
+      * This test case verifies that selecting the remove all marked questions button
+      * will remove the marked question.
+      */
+     public void testImpl() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          Configuration configuration = mainFrame.getConfiguration();
+          configuration.load(CONFIG_NAME, true);
+
+          ConfigDialog config = configuration.openByKey();
+          String[] names = config.getElementsNames();
+          int[] indexes = new int[] { -1, -1 };
+          int i = 0;
+          for (String s : names) {
+               if ("Concurrency".equalsIgnoreCase(s.trim())) {
+                    indexes[0] = i;
+               }
+               if ("Time Factor".equalsIgnoreCase(s.trim())) {
+                    indexes[1] = i;
+               }
+               if (indexes[1] > 0) {
+                    break;
+               }
+               i++;
+          }
+          config.getBookmarks_EnableBookmarks().push();
+          setSomeValues(config.getConfigDialog(), indexes);
+          config.setBookmarkedByMenu(indexes);
+          config.getBookmarks_ClearAnswerToBookmarkedQuestionsMenu().push();
+          checkValues(config.getConfigDialog(), indexes);
+
+     }
+
+     private void checkValues(JDialogOperator config, int[] indexes) {
+          JListOperator list = new JListOperator(config);
+
+          list.selectItem(indexes[0]);
+          if (!(new JTextFieldOperator(config, new NameComponentChooser("int.field.txt")).getText().equals("1"))) {
+               throw new JemmyException("Value in Concurrency was not reset");
+          }
+          list.selectItem(indexes[1]);
+          if (!(new JTextFieldOperator(config, new NameComponentChooser("flt.field.txt")).getText().equals("1"))) {
+               throw new JemmyException("Value in Time Factor was not reset");
+          }
+     }
+
+     private void setSomeValues(JDialogOperator config, int[] indexes) {
+          JListOperator list = new JListOperator(config);
+
+          list.selectItem(indexes[0]);
+          new JTextFieldOperator(config, new NameComponentChooser("int.field.txt")).setText("");
+          new JTextFieldOperator(config, new NameComponentChooser("int.field.txt")).typeText("22");
+          list.selectItem(indexes[1]);
+          new JTextFieldOperator(config, new NameComponentChooser("flt.field.txt")).setText("");
+          new JTextFieldOperator(config, new NameComponentChooser("flt.field.txt")).typeText("22");
+     }
+
+     @Override
+     public String getDescription() {
+          return "Start JavaTest with the -NewDesktop option. Create a workdirectory. Load an existing JTI file. Bring up configuration editor by doing Ctrl-E. Select the Enable Bookmarks from the Bookmarks menu. Select couple of questions from the history list. Bring up the popup menu and mark the all the questions. Bring up the Clear Answers to Marked Questions from the Bookmarks menu. Verify that all the selected questions should be have empty answers.";
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ReportConverter/ReportConverter1.java
+++ b/gui-tests/src/gui/src/jthtest/ReportConverter/ReportConverter1.java
@@ -1,0 +1,80 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ReportConverter;
+
+import jthtest.Test;
+import jthtest.tools.JTFrame;
+import jthtest.tools.Task.Waiter;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JEditorPaneOperator;
+
+public class ReportConverter1 extends Test {
+     String find1 = "Greetings!Thistoolisusedtomergemanyxmlreportsintoone.Selectoutputdirectoryand2ormorexmlreports.";
+     String find2 = "Greetings!Thistoolisusedtomergemanyxmlreportsintoone.PushSettings->New...menutoopenconverterdialog.orSettings->Opentoopenafileforreading";
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+          mainFrame.getTools_ReportConverterMenu().push();
+
+          JEditorPaneOperator op = new JEditorPaneOperator(mainFrame.getJFrameOperator());
+          Waiter waiter = new WaiterImpl(op, find1);
+          waiter.waitForDone();
+
+          JDialogOperator d = new JDialogOperator("Create a Report");
+          new JButtonOperator(d, "Cancel").push();
+
+          waiter = new WaiterImpl(op, find2);
+          waiter.waitForDone();
+     }
+
+     private static class WaiterImpl extends Waiter {
+          private final JEditorPaneOperator editpane;
+          private final String toFind;
+
+          public WaiterImpl(JEditorPaneOperator op, String toFind) {
+               super(false);
+               this.editpane = op;
+               if (toFind == null || toFind.equals("")) {
+                    throw new IllegalArgumentException();
+               }
+               this.toFind = toFind.replaceAll("[\t\n\r\f ]", "");
+               start();
+          }
+
+          @Override
+          protected boolean check() {
+               String txt = editpane.getDisplayedText();
+               if (txt == null)
+                    return false;
+               String text = txt.replaceAll("[\t\n\r\f ]", "");
+               return text != null && text.equals(toFind);
+          }
+     }
+
+}

--- a/gui-tests/src/gui/src/jthtest/StandardConfig_View/View.java
+++ b/gui-tests/src/gui/src/jthtest/StandardConfig_View/View.java
@@ -1,0 +1,50 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.StandardConfig_View;
+
+import jthtest.Tools;
+import java.lang.reflect.InvocationTargetException;
+import org.junit.Before;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+
+public class View extends Tools {
+     protected JFrameOperator mainFrame;
+
+        public JDialogOperator callNewConfigurationEditor() {
+            new JMenuOperator(mainFrame, "Configure").pushMenuNoBlock("Configure|New Configuration", "|");
+            return findConfigEditor(mainFrame);
+        }/**/
+
+        @Before
+        public void setUp() throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+          startJavatest(NEWDESKTOP_ARG);
+          mainFrame = findMainFrame();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/StandardConfig_View/View.java
+++ b/gui-tests/src/gui/src/jthtest/StandardConfig_View/View.java
@@ -40,7 +40,7 @@ public class View extends Tools {
         public JDialogOperator callNewConfigurationEditor() {
             new JMenuOperator(mainFrame, "Configure").pushMenuNoBlock("Configure|New Configuration", "|");
             return findConfigEditor(mainFrame);
-        }/**/
+        }
 
         @Before
         public void setUp() throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {

--- a/gui-tests/src/gui/src/jthtest/StandardConfig_View/View2.java
+++ b/gui-tests/src/gui/src/jthtest/StandardConfig_View/View2.java
@@ -1,0 +1,51 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.StandardConfig_View;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+
+public class View2 extends View {
+
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.StandardConfig_View.View2");
+     }
+
+     @Test
+     public void testView2() {
+          openTestSuite(mainFrame);
+          createWorkDirInTemp(mainFrame);
+          JDialogOperator editor = callNewConfigurationEditor();
+          new JMenuOperator(editor, "View").pushMenuNoBlock("View|Quick Set Mode", "|");
+          checkPanel();
+          new JMenuOperator(editor, "View").pushMenuNoBlock("View|Question Mode", "|");
+          checkPanel();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/StandardConfig_View/View3.java
+++ b/gui-tests/src/gui/src/jthtest/StandardConfig_View/View3.java
@@ -1,0 +1,49 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.StandardConfig_View;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+
+public class View3 extends View {
+
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.StandardConfig_View.View3");
+     }
+
+     @Test
+     public void testView3() {
+          openTestSuite(mainFrame);
+          createWorkDirInTemp(mainFrame);
+          JDialogOperator editor = callNewConfigurationEditor();
+          new JMenuOperator(editor, "View").pushMenuNoBlock("View|More Info", "|");
+          checkPanel();
+     }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. Markers22.java
2. ReportConverter1.java
3. View2.java
4. View3.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903718](https://bugs.openjdk.org/browse/CODETOOLS-7903718): Feature Tests - Adding four JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.org/jtharness.git pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/71.diff">https://git.openjdk.org/jtharness/pull/71.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/71#issuecomment-2069062682)