### PR TITLE
7903757: Feature Tests - Fixing 'CreateWorkdir06' due to compilation error

### DIFF
--- a/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java
+++ b/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java
@@ -41,7 +41,7 @@ public class CreateWorkdir06 extends Test {
 
      JFrameOperator mainFrame;
 
-     public CreateWorkdir02() {
+     public CreateWorkdir06() {
      depricated = true;
      }
 


### PR DESCRIPTION
Fixing 'CreateWorkdir06' test script due to compilation error.

```
    [javac] Compiling 189 source files to /scratch/files/jenkins/workspace/QA/javatest/jt_gui_automation_verification/jt_gui_lin/jtharness/gui-tests/src/build/tests/gui/classes
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 8
    [javac] /scratch/files/jenkins/workspace/QA/javatest/jt_gui_automation_verification/jt_gui_lin/jtharness/gui-tests/src/gui/src/jthtest/CreateWorkdir/CreateWorkdir06.java:44: error: invalid method declaration; return type required
    [javac] public CreateWorkdir02() {
    [javac] ^
    [javac] 1 error
    [javac] 1 warning
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903757](https://bugs.openjdk.org/browse/CODETOOLS-7903757): Feature Tests - Fixing 'CreateWorkdir06' due to compilation error (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/jtharness.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/72.diff">https://git.openjdk.org/jtharness/pull/72.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/72#issuecomment-2180595167)