### PR TITLE
7903761: Test jthtest.TestTree.TestTree3 fails consistently with JDK17/Linux

### DIFF
--- a/gui-tests/src/build.xml
+++ b/gui-tests/src/build.xml
@@ -281,6 +281,10 @@
             <formatter type="xml"/>
             <formatter type="plain"/>
 
+            <batchtest fork="true" todir="${report.dir}">
+               <fileset dir="${tests.gui.srcpath}" includes="*/TestTree/*.java" />
+            </batchtest>
+
             <batchtest fork="true" todir="${report.dir}" unless="testfile">
                 <fileset dir="${tests.gui.srcpath}">
                     <include name="**/*0.java"/>
@@ -293,6 +297,7 @@
                     <include name="**/*7.java"/>
                     <include name="**/*8.java"/>
                     <include name="**/*9.java"/>
+                    <exclude name="*/TestTree/*.java" />
                 </fileset>
             </batchtest>
             <batchtest fork="true" todir="${report.dir}" if="testfile">


### PR DESCRIPTION
TestTree3 is using config 'democonfig.jti' file and this config file is being modified by the test 'Test_QSM_Save1'. Due to this modification of config file(Tools.CONFIG_NAME), the test script TestTree3.java is failing.

In test suite 'Test_QSM_Save1' is executing first and later 'TestTree' tests are getting executed. This causing the issue.

      mainFrame = new JTFrame(true);

      mainFrame.openDefaultTestSuite();
      addUsedFile(mainFrame.createWorkDirectoryInTemp());
      mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);

      TestTree tree = mainFrame.getTestTree();

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903761](https://bugs.openjdk.org/browse/CODETOOLS-7903761): Test jthtest.TestTree.TestTree3 fails consistently with JDK17/Linux (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jtharness.git pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/74.diff">https://git.openjdk.org/jtharness/pull/74.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/74#issuecomment-2208911801)