### PR TITLE
7903768: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/KFL/KFL10.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL10.java
@@ -1,0 +1,50 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL10 extends KFL {
+
+     public KFL10() throws FileNotFoundException, IOException {
+          super(null, new KFLValues(4, 0, 0, 0, 1, 0, 3, 8, 0, 0, 3, 0, 5), TESTCASES_TEST_SUITE_NAME);
+     }
+
+     protected void init() throws Exception {
+          FileWriter out = new FileWriter(DEFAULT_PATH + File.separator + "kfl.kfl");
+          out.write(
+                    "TestCasesTests/FailingTest1.java[FailingTest01]\nTestCasesTests/FailingTest1.java[FailingTest02]\nTestCasesTests/FailingTest1.java[FailingTest03]");
+          out.flush();
+          out.close();
+          this.kfl = "kfl.kfl";
+          addUsedFile("kfl.kfl");
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/KFL/KFL6.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL6.java
@@ -1,0 +1,43 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL6 extends KFL {
+
+     public KFL6() {
+          super(KFL_MISSING_PATH, new KFLValues(8, 0, -1, 0, 5, 0, 3, -1, -1, -1, -1, -1, -1));
+     }
+
+     @Override
+     public void initReportDialog() {
+          rd.setKFLCheckForTestcases(false);
+          rd.setKFLFail2Error(false);
+          jthtest.Tools.pause(1);
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/KFL/KFL7.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL7.java
@@ -1,0 +1,41 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL7 extends KFL {
+
+     public KFL7() {
+          super(KFL_MISSING_PATH, new KFLValues(8, -1, 0, 0, 5, 0, 3, 5, 0, 0, 0, 0, 5));
+     }
+
+     @Override
+     public void initReportDialog() {
+          rd.setKFLFail2Fail(false);
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/KFL/KFL8.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL8.java
@@ -1,0 +1,41 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL8 extends KFL {
+
+    public KFL8() {
+         super(KFL_MISSING_PATH, new KFLValues(3, 0, 0, 0, -1, 0, 3, 5, 0, 0, -1, 0, 5));
+    }
+
+    @Override
+    public void initReportDialog() {
+        rd.setKFLFail2Missing(false);
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/KFL/KFL9.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL9.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL9 extends KFL {
+
+    public KFL9() {
+         super(KFL_TC_ALL_PATH, new KFLValues(8, 0, 0, 0, 5, 0, 3, 27, 0, 0, 22, 0, 5), TESTCASES_TEST_SUITE_NAME);
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. KFL6.java
2. KFL7.java
3. KFL8.java
4. KFL9.java
5. KFL10.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903768](https://bugs.openjdk.org/browse/CODETOOLS-7903768): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/jtharness.git pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/76.diff">https://git.openjdk.org/jtharness/pull/76.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/76#issuecomment-2211074285)