### PR TITLE
7903769: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/KFL/KFL11.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL11.java
@@ -1,0 +1,49 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL11 extends KFL {
+
+    public KFL11() throws FileNotFoundException, IOException {
+         super(null, new KFLValues(5, 0, 0, 0, 2, 0, 3, 8, 0, 0, 3, 0, 5), TESTCASES_TEST_SUITE_NAME);
+    }
+
+    protected void init() throws Exception {
+        FileWriter out = new FileWriter(DEFAULT_PATH + File.separator + "kfl.kfl");
+        out.write("TestCasesTests/ErrorTest.java[ErrorTest01]\nTestCasesTests/ManyTest.java[ErrorTest01]\nTestCasesTests/ManyTest.java[ErrorTest02]");
+        out.flush();
+        out.close();
+        this.kfl = "kfl.kfl";
+        addUsedFile("kfl.kfl");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/KFL/KFL12.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL12.java
@@ -1,0 +1,49 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL12 extends KFL {
+
+    public KFL12() throws FileNotFoundException, IOException {
+         super(null, new KFLValues(5, 0, 0, 0, 2, 0, 3, 7, 0, 0, 2, 0, 5), TESTCASES_TEST_SUITE_NAME);
+    }
+
+    protected void init() throws Exception {
+        FileWriter out = new FileWriter(DEFAULT_PATH + File.separator + "kfl.kfl");
+        out.write("TestCasesTests/Missing.java[ErrorTest01]\nTestCasesTests/ManyTest.java[MissingTest01]");
+        out.flush();
+        out.close();
+        this.kfl = "kfl.kfl";
+        addUsedFile("kfl.kfl");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/KFL/KFL13.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL13.java
@@ -1,0 +1,49 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL13 extends KFL {
+
+    public KFL13() throws FileNotFoundException, IOException {
+        super(null, new KFLValues(3, 0, 0, 0, 0, 0, 3, 5, 0, 0, 0, 0, 5), TESTCASES_TEST_SUITE_NAME);
+    }
+
+    protected void init() throws Exception {
+        FileWriter out = new FileWriter(DEFAULT_PATH + File.separator + "kfl.kfl");
+        out.write("#EMPTY_KFL_LIST");
+        out.flush();
+        out.close();
+        this.kfl = "kfl.kfl";
+        addUsedFile("kfl.kfl");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/KFL/KFL14.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL14.java
@@ -1,0 +1,49 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL14 extends KFL {
+
+    public KFL14() throws FileNotFoundException, IOException {
+         super(null, new KFLValues(4, 0, 0, 0, 1, 0, 3, 7, 0, 0, 2, 0, 5), TESTCASES_TEST_SUITE_NAME);
+    }
+
+    protected void init() throws Exception {
+        FileWriter out = new FileWriter(DEFAULT_PATH + File.separator + "kfl.kfl");
+        out.write("TestCasesTests/FailingTest1.java[FailingTest01]\nTestCasesTests/FailingTest1.java[FailingTest02]");
+        out.flush();
+        out.close();
+        this.kfl = "kfl.kfl";
+        addUsedFile("kfl.kfl");
+    }
+}

--- a/gui-tests/src/gui/src/jthtest/KFL/KFL15.java
+++ b/gui-tests/src/gui/src/jthtest/KFL/KFL15.java
@@ -1,0 +1,49 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.KFL;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import jthtest.tools.ReportChecker.KFLValues;
+
+public class KFL15 extends KFL {
+
+    public KFL15() throws FileNotFoundException, IOException {
+         super(null, new KFLValues(4, 0, 0, 0, 1, 0, 3, 6, 0, 0, 1, 0, 5), TESTCASES_TEST_SUITE_NAME);
+    }
+
+    protected void init() throws Exception {
+        FileWriter out = new FileWriter(DEFAULT_PATH + File.separator + "kfl.kfl");
+        out.write("TestCasesTests/FailingTest2.java[FailingTest01]\n");
+        out.flush();
+        out.close();
+        this.kfl = "kfl.kfl";
+        addUsedFile("kfl.kfl");
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS) and working fine. Also verified with JDK8 on macos.

1. KFL11.java
2. KFL12.java
3. KFL13.java
4. KFL14.java
5. KFL15.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903769](https://bugs.openjdk.org/browse/CODETOOLS-7903769): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/jtharness.git pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/77.diff">https://git.openjdk.org/jtharness/pull/77.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/77#issuecomment-2211167220)
</details>
