### PR TITLE
7903773: Feature Tests - Adding four JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter11.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter11.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * To change this template, choose Browse | Templates
+ * and open the template in the editor.
+ */
+package jthtest.ViewFilter;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+/**
+ *
+ * @author naryl
+ */
+public class ViewFilter11 extends ViewFilter {
+
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter11");
+     }
+
+     @Test
+     public void testViewFilter11() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+//
+//          startWithDefaultWorkdir();
+//
+//          selectFilter(mainFrame, "Custom");
+//
+//          setKeywordFilter(mainFrame, 1, "kk6");
+//
+//          new JDialogOperator("Error").close();
+//
+     }
+
+}
+

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter14.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter14.java
@@ -1,0 +1,59 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ViewFilter;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+/**
+ *
+ * @author naryl
+ */
+public class ViewFilter14 extends ViewFilter {
+
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter14");
+     }
+
+     @Test
+     public void testViewFilter14() throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+//          startWithDefaultWorkdir();
+//
+//          selectFilter(mainFrame, "Custom");
+//
+//          setKeywordFilter(mainFrame, 2, "kk6");
+//
+//          new JDialogOperator("Error").close();
+
+     }
+
+}
+

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter15.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter15.java
@@ -1,0 +1,56 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ViewFilter;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+/**
+ *
+ * @author naryl
+ */
+public class ViewFilter15 extends ViewFilter {
+
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter15");
+     }
+
+     @Test
+     public void testViewFilter15() throws InterruptedException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+          startWithRunWorkdir();
+
+          setPrevStateFilter(mainFrame, "Failed");
+
+          //checkAllTestLists(mainFrame, null, failedListsTests, null, null, concat(bignumTests, passedListsTests));
+
+     }
+
+}
+

--- a/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter9.java
+++ b/gui-tests/src/gui/src/jthtest/ViewFilter/ViewFilter9.java
@@ -1,0 +1,59 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.ViewFilter;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+/**
+ *
+ * @author naryl
+ */
+public class ViewFilter9 extends ViewFilter {
+
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ViewFilter.ViewFilter9");
+     }
+
+     @Test
+     public void testViewFilter9() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+//          startWithDefaultWorkdir();
+//
+//          selectFilter(mainFrame, "Custom");
+//
+//          setKeywordFilter(mainFrame, 0, "kk6");
+//
+//          new JDialogOperator("Error").close();
+
+     }
+
+}
+


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux and Mac OS) and working fine.

1. ViewFilter9.java
2. ViewFilter11.java
3. ViewFilter14.java
4. ViewFilter15.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903773](https://bugs.openjdk.org/browse/CODETOOLS-7903773): Feature Tests - Adding four JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.org/jtharness.git pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/80.diff">https://git.openjdk.org/jtharness/pull/80.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/80#issuecomment-2221380167)