### PR TITLE
7900303: auto updating components need accessbility control

### DIFF
--- a/doc/deliverables/ReleaseNotes-jtharness.html
+++ b/doc/deliverables/ReleaseNotes-jtharness.html
@@ -488,6 +488,13 @@ the test suite uses an agent. See your test suite documentation for
 detailed information about the agent that it uses and its use of the
 Agent Monitor tool.</p>
 
+<h4>Hiding Test Run Progress Bars</h4>
+
+<p>JT Harness allows you to hide the auto-updated progress bars that reflect
+the progress of a test run in the GUI. To do this, start JTHarness with
+the system property <code>javatest.desktop.testrunprogressmonitor.hidden</code> set
+to <code>true</code>.</p>
+
 <p class="navtop"><a href="#top">Top&nbsp;<img src="shared/topicon.gif" alt="go to TOC"></a></p>
 </div>
 <hr>

--- a/doc/deliverables/ReleaseNotes-jtharness.html
+++ b/doc/deliverables/ReleaseNotes-jtharness.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!--
-  Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  
   This code is free software; you can redistribute it and/or modify it
@@ -499,7 +499,7 @@ to <code>true</code>.</p>
 </div>
 <hr>
     
-<p class="copyright"><a href="../../legal/copyright.txt">Copyright</a> &copy; 2011, 2022, Oracle and/or its affiliates. All rights reserved. The JT Harness project is released under the <A HREF="LICENSE">GNU General Public License Version 2 (GPLv2)</A>.
+<p class="copyright"><a href="../../legal/copyright.txt">Copyright</a> &copy; 2011, 2024, Oracle and/or its affiliates. All rights reserved. The JT Harness project is released under the <A HREF="LICENSE">GNU General Public License Version 2 (GPLv2)</A>.
 </p>
 </body>
 </html>

--- a/src/com/sun/javatest/exec/ProgressMonitor.java
+++ b/src/com/sun/javatest/exec/ProgressMonitor.java
@@ -373,11 +373,18 @@ class ProgressMonitor extends ToolDialog {
             actions[actions.length - 1] = "-1";
             */
 
+            meter = new ProgressMeter(colors, state);
             tf = uif.createHeading("pm.tests.mtr");
             uif.setAccessibleInfo(tf, "pm.tests.mtr");
-            add(tf, lnc);
-            add(meter = new ProgressMeter(colors, state), rc);
             uif.setAccessibleInfo(meter, "pm.tests.bar");
+
+            boolean showTestRunProgressMonitor =
+                    !Boolean.valueOf(System.getProperty("javatest.desktop.testrunprogressmonitor.hidden"));
+
+            if (showTestRunProgressMonitor) {
+                add(tf, lnc);
+                add(meter, rc);
+            }
             /*
             meter.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 

--- a/src/com/sun/javatest/exec/RunProgressMonitor.java
+++ b/src/com/sun/javatest/exec/RunProgressMonitor.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2001, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/com/sun/javatest/exec/RunTestsHandler.java
+++ b/src/com/sun/javatest/exec/RunTestsHandler.java
@@ -237,14 +237,24 @@ class RunTestsHandler implements ET_RunTestControl, Session.Observer {
 
     MessageStrip getMessageStrip() {
         if (messageStrip == null) {
-            Monitor[] monitors = new Monitor[2];
-            monitors[0] = new ElapsedTimeMonitor(mState, uif);
-            monitors[1] = new RunProgressMonitor(mState, uif);
 
             ActionListener zoom = e -> setProgressMonitorVisible(!isProgressMonitorVisible());
-            messageStrip = new MessageStrip(uif, monitors, mState, zoom);
-            messageStrip.setRunningMonitor(monitors[1]);
-            messageStrip.setIdleMonitor(monitors[0]);
+
+            ElapsedTimeMonitor elapsedTime = new ElapsedTimeMonitor(mState, uif);
+
+            boolean showTestRunProgressMonitor =
+                    !Boolean.valueOf(System.getProperty("javatest.desktop.testrunprogressmonitor.hidden"));
+
+            if (showTestRunProgressMonitor) {
+                RunProgressMonitor runProgress = new RunProgressMonitor(mState, uif);
+                messageStrip = new MessageStrip(uif, new Monitor[] { elapsedTime, runProgress }, mState, zoom);
+                messageStrip.setRunningMonitor(runProgress);
+                messageStrip.setIdleMonitor(elapsedTime);
+            } else {
+                messageStrip = new MessageStrip(uif, new Monitor[] { elapsedTime }, mState, zoom);
+                messageStrip.setRunningMonitor(elapsedTime);
+            }
+
             harness.addObserver(messageStrip);
         }
 

--- a/src/com/sun/javatest/exec/RunTestsHandler.java
+++ b/src/com/sun/javatest/exec/RunTestsHandler.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The auto-updating component that can be improved in JTHarness UI in terms of accessibility is test run progress bar.

Such progress bars are visible on the main desktop and in test run monitor window.

We should provide a mechanism for the user to hide test run progress bars.

### Default state

![Screenshot 2024-08-30 at 09 47 36](https://github.com/user-attachments/assets/6cfcac77-a471-4d40-aeab-e6bd43cc6469)

![Screenshot 2024-08-30 at 09 40 22](https://github.com/user-attachments/assets/c88eceec-ab04-48e6-928f-da67d08938f3)

Visually unchanged comparing to what we have now, without the patch.

### Started with `-Djavatest.desktop.testrunprogressmonitor.hidden=true`

![Screenshot 2024-08-30 at 09 48 01](https://github.com/user-attachments/assets/4552e637-61b2-43a5-80bb-73ef97b34226)

![Screenshot 2024-08-30 at 09 46 43](https://github.com/user-attachments/assets/5d6a5bf1-cda1-4cca-943a-c68a91f7049c)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7900303](https://bugs.openjdk.org/browse/CODETOOLS-7900303): auto updating components need accessbility control (**Enhancement** - P3)


### Reviewers
 * [Alexandre Iline](https://openjdk.org/census#shurailine) - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/jtharness.git pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/82.diff">https://git.openjdk.org/jtharness/pull/82.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/82#issuecomment-2320567361)