### PR TITLE
7903812: Extract property name added with CODETOOLS-7900303 to a string constant

### DIFF
--- a/src/com/sun/javatest/exec/ProgressMonitor.java
+++ b/src/com/sun/javatest/exec/ProgressMonitor.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2001, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package com.sun.javatest.exec;
 
 import com.sun.javatest.Status;
 import com.sun.javatest.TestResult;
+import com.sun.javatest.tool.Desktop;
 import com.sun.javatest.tool.I18NUtils;
 import com.sun.javatest.tool.ToolDialog;
 import com.sun.javatest.tool.UIFactory;
@@ -379,7 +380,7 @@ class ProgressMonitor extends ToolDialog {
             uif.setAccessibleInfo(meter, "pm.tests.bar");
 
             boolean showTestRunProgressMonitor =
-                    !Boolean.valueOf(System.getProperty("javatest.desktop.testrunprogressmonitor.hidden"));
+                    !Boolean.valueOf(System.getProperty(Desktop.TESTRUN_PROGRESSMONITOR_HIDDEN));
 
             if (showTestRunProgressMonitor) {
                 add(tf, lnc);

--- a/src/com/sun/javatest/exec/RunTestsHandler.java
+++ b/src/com/sun/javatest/exec/RunTestsHandler.java
@@ -32,6 +32,7 @@ import com.sun.javatest.Parameters;
 import com.sun.javatest.TestSuite;
 import com.sun.javatest.WorkDirectory;
 import com.sun.javatest.exec.Session.Event;
+import com.sun.javatest.tool.Desktop;
 import com.sun.javatest.tool.Preferences;
 import com.sun.javatest.tool.ToolAction;
 import com.sun.javatest.tool.UIFactory;
@@ -243,7 +244,7 @@ class RunTestsHandler implements ET_RunTestControl, Session.Observer {
             ElapsedTimeMonitor elapsedTime = new ElapsedTimeMonitor(mState, uif);
 
             boolean showTestRunProgressMonitor =
-                    !Boolean.valueOf(System.getProperty("javatest.desktop.testrunprogressmonitor.hidden"));
+                    !Boolean.valueOf(System.getProperty(Desktop.TESTRUN_PROGRESSMONITOR_HIDDEN));
 
             if (showTestRunProgressMonitor) {
                 RunProgressMonitor runProgress = new RunProgressMonitor(mState, uif);

--- a/src/com/sun/javatest/tool/Desktop.java
+++ b/src/com/sun/javatest/tool/Desktop.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,6 +125,14 @@ public class Desktop {
      * multiple top-level windows, one per tool.
      */
     public static final int SDI_STYLE = 2;
+
+    /**
+     * JT Harness allows you to hide the auto-updated progress bars that reflect
+     * the progress of a test run in the GUI. To do this, start JT Harness with
+     * this system property set to 'true'.
+     */
+    public static final String TESTRUN_PROGRESSMONITOR_HIDDEN = "javatest.desktop.testrunprogressmonitor.hidden";
+
     static final int NUM_STYLES = 3;
     static final String[] styleNames = {"tab", "mdi", "sdi"};
     static final String STYLE_PREF = "tool.appearance.style";


### PR DESCRIPTION
A string constant can be used for the property "javatest.desktop.testrunprogressmonitor.hidden" introduced by [CODETOOLS-7900303](https://bugs.openjdk.org/browse/CODETOOLS-7900303)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903812](https://bugs.openjdk.org/browse/CODETOOLS-7903812): Extract property name added with CODETOOLS-7900303 to a string constant (**Enhancement** - P3)


### Reviewers
 * [Alexandre Iline](https://openjdk.org/census#shurailine) - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.org/jtharness.git pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/83.diff">https://git.openjdk.org/jtharness/pull/83.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/83#issuecomment-2324344281)