### PR TITLE
7903820: Feature Tests - Adding 'product.name=JT' in build script

### DIFF
--- a/gui-tests/src/build.xml
+++ b/gui-tests/src/build.xml
@@ -42,6 +42,7 @@
     <property name="htmlreport.dir" value="${tests.tempdir}/htmlreport"/>
 
     <property name="inittimeout" value="300000"/>
+    <property name="product.name" value="JT" />
 
     <path id="classpath">
         <fileset dir="${tests.tempdir}">
@@ -281,7 +282,7 @@
             <formatter type="xml"/>
             <formatter type="plain"/>
 
-            <batchtest fork="true" todir="${report.dir}">
+            <batchtest fork="true" todir="${report.dir}" unless="testfile">
                <fileset dir="${tests.gui.srcpath}" includes="*/TestTree/*.java" />
             </batchtest>
 

--- a/gui-tests/src/build.xml
+++ b/gui-tests/src/build.xml
@@ -282,7 +282,7 @@
             <formatter type="xml"/>
             <formatter type="plain"/>
 
-            <batchtest fork="true" todir="${report.dir}" unless="testfile">
+            <batchtest fork="true" todir="${report.dir}">
                <fileset dir="${tests.gui.srcpath}" includes="*/TestTree/*.java" />
             </batchtest>
 


### PR DESCRIPTION
Adding 'product.name=JT' in build.xml file.

This option 'product.name=JT' is required to run the KFL test scripts.

```
==================
index 2f6d019..008c97a 100644
--- a/gui-tests/src/build.xml
+++ b/gui-tests/src/build.xml
@@ -42,6 +42,7 @@
     <property name="htmlreport.dir" value="${tests.tempdir}/htmlreport"/>

     <property name="inittimeout" value="300000"/>
+    <property name="product.name" value="JT" />

     <path id="classpath">
         <fileset dir="${tests.tempdir}">
@@ -281,7 +282,7 @@
             <formatter type="xml"/>
             <formatter type="plain"/>

-            <batchtest fork="true" todir="${report.dir}">
+            <batchtest fork="true" todir="${report.dir}" unless="testfile">
                <fileset dir="${tests.gui.srcpath}" includes="*/TestTree/*.java" />
             </batchtest>
==================
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903820](https://bugs.openjdk.org/browse/CODETOOLS-7903820): Feature Tests - Adding 'product.name=JT' in build script (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.org/jtharness.git pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/84.diff">https://git.openjdk.org/jtharness/pull/84.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/84#issuecomment-2346525717)