### PR TITLE
7903862: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree10.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree10.java
@@ -1,0 +1,97 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.TestTree;
+
+import javax.swing.tree.TreePath;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+import com.sun.javatest.tool.IconFactory;
+import javax.swing.Icon;
+
+public class TestTree10 extends Test {
+
+     /**
+      * This test runs all tests firstly by menu and then after clearing by mouse and
+      * checks icons
+      */
+
+     private TestTree tree;
+     private Icon passedTest = IconFactory.getTestIcon(IconFactory.PASSED, false, true);
+     private Icon failedTest = IconFactory.getTestIcon(IconFactory.FAILED, false, true);
+     private Icon passedTestFolder = IconFactory.getTestFolderIcon(IconFactory.PASSED, false, true);
+     private Icon failedTestFolder = IconFactory.getTestFolderIcon(IconFactory.FAILED, false, true);
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          mainFrame.runTests().waitForDone();
+          checkTests();
+          tree.clearResults();
+          tree.runAllTests().waitForDone();
+          checkTests();
+     }
+
+     private void checkTests() {
+          for (int i = 1; i < tree.getVisibleRowCount(); i++) {
+               TreePath path = tree.getPathForRow(i);
+               Icon icon = tree.getIcon(path);
+               if (i == 0) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Tree root icon is not failed as expected");
+                    }
+               } else if (i == 8) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 9) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 12) {
+                    if (icon != failedTest) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               }
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree6.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree6.java
@@ -1,0 +1,75 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+
+public class TestTree6 extends Test {
+
+     /**
+      * This test checks that collapsing and expanding again nesting test folder will
+      * not collapse nested test folders
+      */
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          TestTree tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          if (tree.getVisibleRowCount() != 24) {
+               errors.add(
+                         "Tree contains " + tree.getVisibleRowCount() + " rows when 23 expected (all paths are expanded)");
+          }
+
+          tree.click(8);
+
+          if (tree.getVisibleRowCount() != 10) {
+               errors.add("Tree contains " + tree.getVisibleRowCount() + " rows when 9 expected");
+          }
+
+          tree.click(8);
+
+          if (tree.getVisibleRowCount() != 24) {
+               errors.add(
+                         "Tree contains " + tree.getVisibleRowCount() + " rows when 23 expected (all paths are expanded)");
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree7.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree7.java
@@ -1,0 +1,98 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.TestTree;
+
+import javax.swing.tree.TreePath;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.Configuration;
+import jthtest.tools.ConfigurationBrowser;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+import com.sun.javatest.tool.IconFactory;
+import javax.swing.Icon;
+
+public class TestTree7 extends Test {
+
+     /**
+      * This test twisely runs all tests by menu and checks icons
+      */
+
+     private TestTree tree;
+     private Icon passedTest = IconFactory.getTestIcon(IconFactory.PASSED, false, true);
+     private Icon failedTest = IconFactory.getTestIcon(IconFactory.FAILED, false, true);
+     private Icon passedTestFolder = IconFactory.getTestFolderIcon(IconFactory.PASSED, false, true);
+     private Icon failedTestFolder = IconFactory.getTestFolderIcon(IconFactory.FAILED, false, true);
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          mainFrame.runTests().waitForDone();
+          checkTests();
+          mainFrame.runTests().waitForDone();
+          checkTests();
+     }
+
+     private void checkTests() {
+          for (int i = 1; i < tree.getVisibleRowCount(); i++) {
+               TreePath path = tree.getPathForRow(i);
+
+               Icon icon = tree.getIcon(path);
+               if (i == 0) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Tree root icon is not failed as expected");
+                    }
+               } else if (i == 8) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 9) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 12) {
+                    if (icon != failedTest) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               }
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree8.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree8.java
@@ -1,0 +1,97 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.TestTree;
+
+import javax.swing.tree.TreePath;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+import com.sun.javatest.tool.IconFactory;
+import javax.swing.Icon;
+
+public class TestTree8 extends Test {
+
+     /**
+      * This test twisely runs all tests by menu clearing results between the
+      * attempts and checks icons
+      */
+
+     private TestTree tree;
+     private Icon passedTest = IconFactory.getTestIcon(IconFactory.PASSED, false, true);
+     private Icon failedTest = IconFactory.getTestIcon(IconFactory.FAILED, false, true);
+     private Icon passedTestFolder = IconFactory.getTestFolderIcon(IconFactory.PASSED, false, true);
+     private Icon failedTestFolder = IconFactory.getTestFolderIcon(IconFactory.FAILED, false, true);
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          mainFrame.runTests().waitForDone();
+          checkTests();
+          tree.clearResults();
+          mainFrame.runTests().waitForDone();
+          checkTests();
+     }
+
+     private void checkTests() {
+          for (int i = 1; i < tree.getVisibleRowCount(); i++) {
+               TreePath path = tree.getPathForRow(i);
+               Icon icon = tree.getIcon(path);
+               if (i == 0) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Tree root icon is not failed as expected");
+                    }
+               } else if (i == 8) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 9) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 12) {
+                    if (icon != failedTest) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               }
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree9.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree9.java
@@ -1,0 +1,95 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.TestTree;
+
+import javax.swing.tree.TreePath;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+import com.sun.javatest.tool.IconFactory;
+import javax.swing.Icon;
+
+public class TestTree9 extends Test {
+
+     /**
+      * This test runs all tests firstly by menu and then by mouse and checks icons
+      */
+
+     private TestTree tree;
+     private Icon passedTest = IconFactory.getTestIcon(IconFactory.PASSED, false, true);
+     private Icon failedTest = IconFactory.getTestIcon(IconFactory.FAILED, false, true);
+     private Icon passedTestFolder = IconFactory.getTestFolderIcon(IconFactory.PASSED, false, true);
+     private Icon failedTestFolder = IconFactory.getTestFolderIcon(IconFactory.FAILED, false, true);
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          mainFrame.runTests().waitForDone();
+          checkTests();
+          tree.runAllTests().waitForDone();
+          checkTests();
+     }
+
+     private void checkTests() {
+          for (int i = 1; i < tree.getVisibleRowCount(); i++) {
+               TreePath path = tree.getPathForRow(i);
+               Icon icon = tree.getIcon(path);
+               if (i == 0) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Tree root icon is not failed as expected");
+                    }
+               } else if (i == 8) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 9) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 12) {
+                    if (icon != failedTest) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               }
+          }
+     }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux and Mac OS) and working fine.

1. TestTree6.java
2. TestTree7.java
3. TestTree8.java
4. TestTree9.java
5. TestTree10.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903862](https://bugs.openjdk.org/browse/CODETOOLS-7903862): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/jtharness.git pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/86.diff">https://git.openjdk.org/jtharness/pull/86.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/86#issuecomment-2415940240)