### PR TITLE
7903863: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE.java
@@ -65,7 +65,8 @@ public abstract class TT_SelectionCE extends Test {
           openTree();
           tree.selectRows(rows);
           make();
-
+          
+          // waiter 10 sec
           Waiter waiter = new Waiter() {
 
                @Override

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE.java
@@ -1,0 +1,99 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import java.util.Arrays;
+import jthtest.Test;
+import jthtest.tools.JTFrame;
+import jthtest.tools.Task.Waiter;
+import jthtest.tools.TestTree;
+
+public abstract class TT_SelectionCE extends Test {
+
+     /**
+      * This is a base class for TT_SelectionCE which contains TestTree functions
+      */
+
+     public TT_SelectionCE(String description, int[] rows) {
+          this.testDescription = description;
+          this.rows = rows;
+     }
+
+     protected abstract void make();
+
+     protected void openTree() {
+          tree.click(2);
+          tree.click(1);
+     }
+
+     protected boolean check(int init[], int res[]) {
+          return !Arrays.equals(init, res);
+     }
+
+     @Override
+     public final void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+
+          tree = mainFrame.getTestTree();
+
+          openTree();
+          tree.selectRows(rows);
+          make();
+
+          // waiter 10 sec
+          Waiter waiter = new Waiter() {
+
+               @Override
+               protected boolean check() {
+                    res = tree.getSelectedRowsIndexes();
+                    if (res == null) {
+                         return false;
+                    }
+                    Arrays.sort(res);
+
+                    return !TT_SelectionCE.this.check(rows, res);
+               }
+
+               int[] res = {};
+
+               @Override
+               protected String getTimeoutExceptionDescription() {
+                    return String.format(
+                              "Error occured - selection lost. Initialy selected rows: %s. After %s selected rows: %s",
+                              Arrays.toString(rows), testDescription, Arrays.toString(res));
+               }
+          };
+
+          waiter.getResult();
+     }
+
+     protected TestTree tree;
+     private String testDescription = "";
+     private int[] rows;
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE.java
@@ -66,7 +66,6 @@ public abstract class TT_SelectionCE extends Test {
           tree.selectRows(rows);
           make();
 
-          // waiter 10 sec
           Waiter waiter = new Waiter() {
 
                @Override

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE.java
@@ -65,7 +65,7 @@ public abstract class TT_SelectionCE extends Test {
           openTree();
           tree.selectRows(rows);
           make();
-          
+
           // waiter 10 sec
           Waiter waiter = new Waiter() {
 

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE1.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE1.java
@@ -1,0 +1,49 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import jthtest.tools.ConfigDialog;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public class TT_SelectionCE1 extends TT_SelectionCE {
+
+     /**
+      * Check that selection on TestTree on main page doesn't dissapear when opening
+      * Create New Configuration and closing it without saving. Includes root path.
+      */
+
+     public TT_SelectionCE1() {
+          super("creating and cancelling ConfigEditor", new int[] { 0, 1, 2, 3, 5, 8, 10 });
+          knownFail = true;
+     }
+
+     public void make() {
+          ConfigDialog cd = mainFrame.getConfiguration().create(true);
+          cd.closeByMenu();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree11.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree11.java
@@ -1,0 +1,97 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.TestTree;
+
+import javax.swing.tree.TreePath;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+import com.sun.javatest.tool.IconFactory;
+import javax.swing.Icon;
+
+public class TestTree11 extends Test {
+
+     /**
+      * This test clears all the tree, then twisely runs all tests by menu and checks
+      * icons
+      */
+
+     private TestTree tree;
+     private Icon passedTest = IconFactory.getTestIcon(IconFactory.PASSED, false, true);
+     private Icon failedTest = IconFactory.getTestIcon(IconFactory.FAILED, false, true);
+     private Icon passedTestFolder = IconFactory.getTestFolderIcon(IconFactory.PASSED, false, true);
+     private Icon failedTestFolder = IconFactory.getTestFolderIcon(IconFactory.FAILED, false, true);
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          tree.clearResults();
+          mainFrame.runTests().waitForDone();
+          checkTests();
+          mainFrame.runTests().waitForDone();
+          checkTests();
+     }
+
+     private void checkTests() {
+          for (int i = 1; i < tree.getVisibleRowCount(); i++) {
+               TreePath path = tree.getPathForRow(i);
+               Icon icon = tree.getIcon(path);
+               if (i == 0) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Tree root icon is not failed as expected");
+                    }
+               } else if (i == 8) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 9) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 12) {
+                    if (icon != failedTest) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               }
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree12.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree12.java
@@ -1,0 +1,98 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.TestTree;
+
+import javax.swing.tree.TreePath;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+import com.sun.javatest.tool.IconFactory;
+import javax.swing.Icon;
+
+public class TestTree12 extends Test {
+
+     /**
+      * This test clears all the tree, then twisely runs all tests by menu clearing
+      * results between the attempts and checks icons
+      */
+
+     private TestTree tree;
+     private Icon passedTest = IconFactory.getTestIcon(IconFactory.PASSED, false, true);
+     private Icon failedTest = IconFactory.getTestIcon(IconFactory.FAILED, false, true);
+     private Icon passedTestFolder = IconFactory.getTestFolderIcon(IconFactory.PASSED, false, true);
+     private Icon failedTestFolder = IconFactory.getTestFolderIcon(IconFactory.FAILED, false, true);
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          tree.clearResults();
+          mainFrame.runTests().waitForDone();
+          checkTests();
+          tree.clearResults();
+          mainFrame.runTests().waitForDone();
+          checkTests();
+     }
+
+     private void checkTests() {
+          for (int i = 1; i < tree.getVisibleRowCount(); i++) {
+               TreePath path = tree.getPathForRow(i);
+               Icon icon = tree.getIcon(path);
+               if (i == 0) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Tree root icon is not failed as expected");
+                    }
+               } else if (i == 8) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 9) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 12) {
+                    if (icon != failedTest) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               }
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree13.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree13.java
@@ -1,0 +1,97 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.TestTree;
+
+import javax.swing.tree.TreePath;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+import com.sun.javatest.tool.IconFactory;
+import javax.swing.Icon;
+
+public class TestTree13 extends Test {
+
+     /**
+      * This test clears all the tree, then runs all tests firstly by menu and then
+      * by mouse and checks icons
+      */
+
+     private TestTree tree;
+     private Icon passedTest = IconFactory.getTestIcon(IconFactory.PASSED, false, true);
+     private Icon failedTest = IconFactory.getTestIcon(IconFactory.FAILED, false, true);
+     private Icon passedTestFolder = IconFactory.getTestFolderIcon(IconFactory.PASSED, false, true);
+     private Icon failedTestFolder = IconFactory.getTestFolderIcon(IconFactory.FAILED, false, true);
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          tree.clearResults();
+          mainFrame.runTests().waitForDone();
+          checkTests();
+          tree.runAllTests().waitForDone();
+          checkTests();
+     }
+
+     private void checkTests() {
+          for (int i = 1; i < tree.getVisibleRowCount(); i++) {
+               TreePath path = tree.getPathForRow(i);
+               Icon icon = tree.getIcon(path);
+               if (i == 0) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Tree root icon is not failed as expected");
+                    }
+               } else if (i == 8) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 9) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 12) {
+                    if (icon != failedTest) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               }
+          }
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TestTree14.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TestTree14.java
@@ -1,0 +1,98 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.TestTree;
+
+import javax.swing.tree.TreePath;
+import jthtest.Test;
+import jthtest.Tools;
+import jthtest.tools.JTFrame;
+import jthtest.tools.TestTree;
+import com.sun.javatest.tool.IconFactory;
+import javax.swing.Icon;
+
+public class TestTree14 extends Test {
+
+     /**
+      * This test clears all the tree, then runs all tests firstly by menu and then
+      * after clearing by mouse and checks icons
+      */
+
+     private TestTree tree;
+     private Icon passedTest = IconFactory.getTestIcon(IconFactory.PASSED, false, true);
+     private Icon failedTest = IconFactory.getTestIcon(IconFactory.FAILED, false, true);
+     private Icon passedTestFolder = IconFactory.getTestFolderIcon(IconFactory.PASSED, false, true);
+     private Icon failedTestFolder = IconFactory.getTestFolderIcon(IconFactory.FAILED, false, true);
+
+     @Override
+     public void testImpl() throws Exception {
+          mainFrame = new JTFrame(true);
+
+          mainFrame.openDefaultTestSuite();
+          addUsedFile(mainFrame.createWorkDirectoryInTemp());
+          mainFrame.getConfiguration().load(Tools.CONFIG_NAME, true);
+
+          tree = mainFrame.getTestTree();
+
+          tree.click(2);
+          tree.click(5);
+          tree.click(4);
+          tree.click(3);
+          tree.click(1);
+
+          tree.clearResults();
+          mainFrame.runTests().waitForDone();
+          checkTests();
+          tree.clearResults();
+          tree.runAllTests().waitForDone();
+          checkTests();
+     }
+
+     private void checkTests() {
+          for (int i = 1; i < tree.getVisibleRowCount(); i++) {
+               TreePath path = tree.getPathForRow(i);
+               Icon icon = tree.getIcon(path);
+               if (i == 0) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Tree root icon is not failed as expected");
+                    }
+               } else if (i == 8) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 9) {
+                    if (icon != failedTestFolder) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               } else if (i == 12) {
+                    if (icon != failedTest) {
+                         errors.add("Icon on path " + path + " is not failed as expected");
+                    }
+               }
+          }
+     }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux and Mac OS) and working fine.

1. TestTree11.java
2. TestTree12.java
3. TestTree13.java
4. TestTree14.java
5. TT_SelectionCE.java
6. TT_SelectionCE1.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903863](https://bugs.openjdk.org/browse/CODETOOLS-7903863): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.org/jtharness.git pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/87.diff">https://git.openjdk.org/jtharness/pull/87.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/87#issuecomment-2415982302)