### PR TITLE
7903864: Feature Tests - Adding five JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE3.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE3.java
@@ -1,0 +1,55 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public class TT_SelectionCE3 extends TT_SelectionCE {
+
+     /**
+      * Check that selection on TestTree on main page doesn't dissapear when opening
+      * Configuration Editor and closing it without any changes. Includes root path.
+      */
+
+     public TT_SelectionCE3() {
+          super("loading and editing (without changes) ConfigEditor", new int[] { 0, 1, 2, 3, 5, 8, 10 });
+          knownFail = true;
+     }
+
+     public void make() {
+          Configuration c = mainFrame.getConfiguration();
+          c.load(CONFIG_NAME, true);
+          ConfigDialog cd = c.openByMenu(true);
+          if (cd.getSelectedQuestionNumber() > 1)
+               cd.pushBackConfigEditor();
+          cd.pushLastConfigEditor();
+          cd.pushDoneConfigEditor();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE4.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE4.java
@@ -1,0 +1,55 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public class TT_SelectionCE4 extends TT_SelectionCE {
+
+     /**
+      * Check that selection on TestTree on main page doesn't dissapear when opening
+      * Configuration Editor and closing it without any changes. Doesn't include root
+      * path.
+      */
+
+     public TT_SelectionCE4() {
+          super("loading and editing (without changes) ConfigEditor", new int[] { 1, 2, 3, 5, 8, 10 });
+     }
+
+     public void make() {
+          Configuration c = mainFrame.getConfiguration();
+          c.load(CONFIG_NAME, true);
+          ConfigDialog cd = c.openByMenu(true);
+          if (cd.getSelectedQuestionNumber() > 1)
+               cd.pushBackConfigEditor();
+          cd.pushLastConfigEditor();
+          cd.pushDoneConfigEditor();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE5.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE5.java
@@ -1,0 +1,62 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class TT_SelectionCE5 extends TT_SelectionCE {
+
+     /**
+      * Check that selection on TestTree on main page doesn't dissapear when editing
+      * unimportant value (Description) in Configuration Editor and closing it with
+      * save. Includes root path.
+      */
+
+     public TT_SelectionCE5() {
+          super("loading and editing (with unimportant changes) ConfigEditor", new int[] { 0, 1, 2, 3, 5, 8, 10 });
+          knownFail = true;
+     }
+
+     public void make() {
+          Configuration c = mainFrame.getConfiguration();
+          c.load(CONFIG_NAME, true);
+          ConfigDialog cd = c.openByMenu(true);
+
+          cd.selectQuestion(2);
+          JTextFieldOperator tf = new JTextFieldOperator(cd.getConfigDialog(), new NameComponentChooser("str.txt"));
+          tf.clearText();
+          tf.typeText("some_new_text");
+
+          cd.pushLastConfigEditor();
+          cd.pushDoneConfigEditor();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE6.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE6.java
@@ -1,0 +1,61 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.Configuration;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+public class TT_SelectionCE6 extends TT_SelectionCE {
+
+     /**
+      * Check that selection on TestTree on main page doesn't dissapear when editing
+      * unimportant value (Description) in Configuration Editor and closing it with
+      * save. Doesn't include root path.
+      */
+
+     public TT_SelectionCE6() {
+          super("loading and editing (with unimportant changes) ConfigEditor", new int[] { 1, 2, 3, 5, 8, 10 });
+     }
+
+     public void make() {
+          Configuration c = mainFrame.getConfiguration();
+          c.load(CONFIG_NAME, true);
+          ConfigDialog cd = c.openByMenu(true);
+
+          cd.selectQuestion(2);
+          JTextFieldOperator tf = new JTextFieldOperator(cd.getConfigDialog(), new NameComponentChooser("str.txt"));
+          tf.clearText();
+          tf.typeText("some_new_text");
+
+          cd.pushLastConfigEditor();
+          cd.pushDoneConfigEditor();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE7.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE7.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.ConfigDialog.QuestionTree;
+import jthtest.tools.Configuration;
+
+public class TT_SelectionCE7 extends TT_SelectionCE {
+
+     /**
+      * Check that selection on TestTree on main page doesn't dissapear when editing
+      * TestsToRun list in Configuration Editor and closing it with save. Includes
+      * root path.
+      */
+
+     public TT_SelectionCE7() {
+          super("loading and editing (with changes in TestsToRun list) ConfigEditor", new int[] { 0, 1, 2, 3, 5, 8, 10 });
+          knownFail = true;
+     }
+
+     public void make() {
+          Configuration c = mainFrame.getConfiguration();
+          c.load(CONFIG_NAME, true);
+          ConfigDialog cd = c.openByMenu(true);
+
+          QuestionTree qt = cd.getQuestionTree();
+          qt.clickOnArrow(1);
+          qt.clickOnArrow(2);
+          qt.clickOnCheckbox(0);
+          qt.clickOnCheckbox(8);
+          qt.clickOnCheckbox(6);
+          qt.clickOnCheckbox(4);
+          qt.clickOnCheckbox(2);
+
+          cd.pushLastConfigEditor();
+          cd.pushDoneConfigEditor();
+     }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux and Mac OS) and working fine.

1. TT_SelectionCE3.java
2. TT_SelectionCE4.java
3. TT_SelectionCE5.java
4. TT_SelectionCE6.java
5. TT_SelectionCE7.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903864](https://bugs.openjdk.org/browse/CODETOOLS-7903864): Feature Tests - Adding five JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/jtharness.git pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/88.diff">https://git.openjdk.org/jtharness/pull/88.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/88#issuecomment-2416038656)