### PR TITLE
7903865: Feature Tests - Adding two JavaTest GUI legacy automated test scripts

### DIFF
--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE8.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE8.java
@@ -1,0 +1,62 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import jthtest.tools.ConfigDialog;
+import jthtest.tools.ConfigDialog.QuestionTree;
+import jthtest.tools.Configuration;
+
+public class TT_SelectionCE8 extends TT_SelectionCE {
+
+     /**
+      * Check that selection on TestTree on main page doesn't dissapear when editing
+      * TestsToRun list in Configuration Editor and closing it with save. Doesn't
+      * include root path.
+      */
+
+     public TT_SelectionCE8() {
+          super("loading and editing (with changes in TestsToRun list) ConfigEditor", new int[] { 1, 2, 3, 5, 8, 10 });
+     }
+
+     public void make() {
+          Configuration c = mainFrame.getConfiguration();
+          c.load(CONFIG_NAME, true);
+          ConfigDialog cd = c.openByMenu(true);
+
+          QuestionTree qt = cd.getQuestionTree();
+          qt.clickOnArrow(1);
+          qt.clickOnArrow(2);
+          qt.clickOnCheckbox(0);
+          qt.clickOnCheckbox(8);
+          qt.clickOnCheckbox(6);
+          qt.clickOnCheckbox(4);
+          qt.clickOnCheckbox(2);
+
+          cd.pushLastConfigEditor();
+          cd.pushDoneConfigEditor();
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE9.java
+++ b/gui-tests/src/gui/src/jthtest/TestTree/TT_SelectionCE9.java
@@ -1,0 +1,53 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jthtest.TestTree;
+
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+
+public class TT_SelectionCE9 extends TT_SelectionCE {
+
+     /**
+      * Check that selection on TestTree on main page doesn't dissapear when editing
+      * TestsToRun list in Configuration Editor and closing it with save. Doesn't
+      * include root path.
+      */
+
+    public TT_SelectionCE9() {
+        super("opening 2 new ExecTools (by TestSuite loading and by new WD creating)", new int[]{0, 1, 5, 7, 9});
+        knownFail = true;
+    }
+
+    @Override
+    protected void make() {
+        mainFrame.openDefaultTestSuite();
+        mainFrame.closeCurrentTool();
+        mainFrame.getFile_CreateWorkDirectoryMenu().push();
+        new JButtonOperator(new JDialogOperator("Create Work Directory"), "Cancel").push();
+        mainFrame.closeCurrentTool();
+    }
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux and Mac OS) and working fine.

1. TT_SelectionCE8.java
2. TT_SelectionCE9.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903865](https://bugs.openjdk.org/browse/CODETOOLS-7903865): Feature Tests - Adding two JavaTest GUI legacy automated test scripts (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/jtharness.git pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/89.diff">https://git.openjdk.org/jtharness/pull/89.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/89#issuecomment-2416058634)