### PR TITLE
7903869: Feature Tests - Fixing TT_SelectionCE test script

### DIFF
--- a/gui-tests/src/build.xml
+++ b/gui-tests/src/build.xml
@@ -282,8 +282,9 @@
             <formatter type="xml"/>
             <formatter type="plain"/>
 
-            <batchtest fork="true" todir="${report.dir}">
+            <batchtest fork="true" todir="${report.dir}" unless="testfile">
                <fileset dir="${tests.gui.srcpath}" includes="*/TestTree/*.java" />
+               <fileset dir="${tests.gui.srcpath}" excludes="*/TestTree/TT_SelectionCE.java" />
             </batchtest>
 
             <batchtest fork="true" todir="${report.dir}" unless="testfile">
@@ -299,6 +300,7 @@
                     <include name="**/*8.java"/>
                     <include name="**/*9.java"/>
                     <exclude name="*/TestTree/*.java" />
+                    <exclude name="*/TestTree/TT_SelectionCE.java" />
                 </fileset>
             </batchtest>
             <batchtest fork="true" todir="${report.dir}" if="testfile">


### PR DESCRIPTION
Base class "TT_SelectionCE" test script is executing, which is not required. So to avoid this adding below line in build.xml

<fileset dir="${tests.gui.srcpath}" excludes="*/TestTree/TT_SelectionCE.java" />

Also, added <unless="testfile"> condition to run the specific tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903869](https://bugs.openjdk.org/browse/CODETOOLS-7903869): Feature Tests - Fixing TT_SelectionCE test script (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jtharness.git pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/90.diff">https://git.openjdk.org/jtharness/pull/90.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/90#issuecomment-2422911314)