### PR TITLE
7903958: JTHarness 6.0 does not show "Test Run Messages" tab correctly

### DIFF
--- a/src/com/sun/javatest/exec/i18n.properties
+++ b/src/com/sun/javatest/exec/i18n.properties
@@ -1947,3 +1947,5 @@ bc.resetWorkDir.err=Attempt to reset work directory
 bc.unknownFilter.err=Unknown filter: {0}
 bc.configNotSet.err=Configuration is not set yet
 bc.unknownProperty.err=Unknown property: {0}
+
+html.lang=en

--- a/src/com/sun/javatest/report/HTMLWriterEx.java
+++ b/src/com/sun/javatest/report/HTMLWriterEx.java
@@ -44,7 +44,7 @@ import java.nio.charset.Charset;
  */
 public class HTMLWriterEx extends HTMLWriter {
 
-    private static final String META_CONTENT = "\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=%s\">\n";
+    private static final String META_CONTENT = "\n<meta http-equiv=\"Content-Type\" content=\"text/html\" charset=\"%s\">\n";
 
     /**
      * Create an HTMLWriterEx object, using a default doctype for HTML 3.2.


### PR DESCRIPTION
- src/com/sun/javatest/exec/i18n.properties is missing `html.lang=en`
 - HTMLWriterEx.META_CONTENT template string contains a typo which leads to generation of an incorrect HTML tag

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903958](https://bugs.openjdk.org/browse/CODETOOLS-7903958): JTHarness 6.0 does not show "Test Run Messages" tab correctly (**Bug** - P2)


### Reviewers
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) (@lkuskov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.org/jtharness.git pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/92.diff">https://git.openjdk.org/jtharness/pull/92.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/92#issuecomment-2691474057)
</details>
