### PR TITLE
7904018: Feature Tests - Adding JavaTest GUI newly automated test scripts.

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind1.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind1.java
@@ -1,0 +1,111 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigSearchFind;
+
+/**
+ * This test case verifies that a string in the interview could be displayed when search option is "In titles".
+ */
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+import jthtest.ConfigTools;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.Dumper;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Config_Load.Config_Load;
+import jthtest.Tools.WDLoadingResult;
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.menu.Menu;
+
+public class ConfigSearchFind1 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigSearchFind.ConfigSearchFind1");
+     }
+
+     @Test
+     public void testConfig_Load1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Load existing configuration file
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+          Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+          // Edit existing Configuration
+          JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+          jmbo.pushMenuNoBlock("Configure", "/");
+          Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+          JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+          JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+          JDialogOperator config = findConfigEditor(mainFrame);
+          pushNextConfigEditor(config);
+
+          // Click on Search and Find from menu
+          jmbo1.pushMenu("Search", "/");
+          jmbo1.pushMenu("Search/Find...", "/");
+          JDialogOperator FindQuestion = new JDialogOperator("Find Question");
+          JTextFieldOperator javastring = new JTextFieldOperator(FindQuestion);
+          javastring.enterText("java");
+          JButtonOperator findButton = new JButtonOperator(FindQuestion, "Find");
+          findButton.doClick();
+          Thread.sleep(2000);
+          ComponentChooser qu = new NameComponentChooser("qu.title");
+          JTextFieldOperator testConfig1 = new JTextFieldOperator(configEditorDialog, qu);
+          Assert.assertTrue("The interview should display the question that has java string in it.",
+                    testConfig1.getText().equals("Java Virtual Machine"));
+     }
+
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind2.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind2.java
@@ -1,0 +1,123 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigSearchFind;
+
+/**
+ * This test case verifies that a string in the interview could be displayed when search option is "In text of questions".
+ */
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+import jthtest.ConfigTools;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JComboBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.Dumper;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Config_Load.Config_Load;
+import jthtest.Tools.WDLoadingResult;
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.menu.Menu;
+
+public class ConfigSearchFind2 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigSearchFind.ConfigSearchFind2");
+     }
+
+     @Test
+     public void testConfig_Load1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Load existing configuration file
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+          Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+          // Edit Configuration
+          JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+          jmbo.pushMenuNoBlock("Configure", "/");
+          Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+          JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+          JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+          JDialogOperator config = findConfigEditor(mainFrame);
+          pushNextConfigEditor(config);
+
+          // Click on Search and Find from menu
+          jmbo1.pushMenu("Search", "/");
+          jmbo1.pushMenu("Search/Find...", "/");
+          JDialogOperator FindQuestion = new JDialogOperator("Find Question");
+          JTextFieldOperator javastring = new JTextFieldOperator(FindQuestion);
+          javastring.enterText("java");
+
+          // Display when search option is "In text of questions".
+          inTextOfQuestions(FindQuestion);
+
+          JButtonOperator findButton = new JButtonOperator(FindQuestion, "Find");
+          findButton.doClick();
+          Thread.sleep(2000);
+          ComponentChooser qu = new NameComponentChooser("file.txt");
+          JTextFieldOperator testConfig1 = new JTextFieldOperator(configEditorDialog, qu);
+          Assert.assertTrue("The interview should display the question that has java string in text of it.",
+                    testConfig1.getText().contains("java"));
+     }
+
+     // Display when search option is "In text of questions".
+     public void inTextOfQuestions(JDialogOperator FindQuestion) {
+          ComponentChooser findWhere = new NameComponentChooser("find.where");
+          JComboBoxOperator jcfind = new JComboBoxOperator(FindQuestion, findWhere);
+          jcfind.selectItem(1);
+     }
+
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind3.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind3.java
@@ -1,0 +1,123 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigSearchFind;
+
+/**
+ * This test case verifies that a string in the interview could be displayed when search option is "In answers".
+ */
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+import jthtest.ConfigTools;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JComboBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.Dumper;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Config_Load.Config_Load;
+import jthtest.Tools.WDLoadingResult;
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.menu.Menu;
+
+public class ConfigSearchFind3 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigSearchFind.ConfigSearchFind3");
+     }
+
+     @Test
+     public void testConfig_Load1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Load existing configuration file
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+          Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+          // Edit Configuration
+          JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+          jmbo.pushMenuNoBlock("Configure", "/");
+          Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+          JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+          JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+          JDialogOperator config = findConfigEditor(mainFrame);
+          pushNextConfigEditor(config);
+
+          // Click on Search and Find from menu
+          jmbo1.pushMenu("Search", "/");
+          jmbo1.pushMenu("Search/Find...", "/");
+          JDialogOperator FindQuestion = new JDialogOperator("Find Question");
+          JTextFieldOperator javastring = new JTextFieldOperator(FindQuestion);
+          javastring.enterText("java");
+
+          // Display when search option is "In answers".
+          inAnswers(FindQuestion);
+
+          JButtonOperator findButton = new JButtonOperator(FindQuestion, "Find");
+          findButton.doClick();
+          Thread.sleep(2000);
+          ComponentChooser qu = new NameComponentChooser("file.txt");
+          JTextFieldOperator testConfig1 = new JTextFieldOperator(configEditorDialog, qu);
+          Assert.assertTrue("The interview should display the question that has java string in answer.",
+                    testConfig1.getText().contains("java"));
+     }
+
+     // Display when search option is "In answers".
+     public void inAnswers(JDialogOperator FindQuestion) {
+          ComponentChooser findWhere = new NameComponentChooser("find.where");
+          JComboBoxOperator jcfind = new JComboBoxOperator(FindQuestion, findWhere);
+          jcfind.selectItem(2);
+     }
+
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind4.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind4.java
@@ -1,0 +1,125 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigSearchFind;
+
+/**
+ * This test case verifies that a string in the interview could be displayed when search option is "Anywhere".
+ */
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+import jthtest.ConfigTools;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JComboBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.Dumper;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Config_Load.Config_Load;
+import jthtest.Tools.WDLoadingResult;
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.menu.Menu;
+
+public class ConfigSearchFind4 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigSearchFind.ConfigSearchFind4");
+     }
+
+     @Test
+     public void testConfig_Load1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Load existing configuration file
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+          Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+          // Edit Configuration
+          JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+          jmbo.pushMenuNoBlock("Configure", "/");
+          Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+          JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+          JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+          JDialogOperator config = findConfigEditor(mainFrame);
+          pushNextConfigEditor(config);
+
+          // Click on Search and Find from menu
+          jmbo1.pushMenu("Search", "/");
+          jmbo1.pushMenu("Search/Find...", "/");
+          JDialogOperator FindQuestion = new JDialogOperator("Find Question");
+          JTextFieldOperator javastring = new JTextFieldOperator(FindQuestion);
+          javastring.enterText("java");
+
+          // Display when search option is "Anywhere".
+          anywhere(FindQuestion);
+
+          JButtonOperator findButton = new JButtonOperator(FindQuestion, "Find");
+          findButton.doClick();
+          Thread.sleep(2000);
+          ComponentChooser qu = new NameComponentChooser("qu.title");
+          ComponentChooser qu1 = new NameComponentChooser("file.txt");
+          JTextFieldOperator testConfig1 = new JTextFieldOperator(configEditorDialog, qu);
+          JTextFieldOperator testConfig2 = new JTextFieldOperator(configEditorDialog, qu1);
+          Assert.assertTrue("The interview should display the question that has java string in any field.",
+                    testConfig1.getText().equals("Java Virtual Machine") || testConfig2.getText().contains("java"));
+     }
+
+     // Display when search option is "Anywhere".
+     public void anywhere(JDialogOperator FindQuestion) {
+          ComponentChooser findWhere = new NameComponentChooser("find.where");
+          JComboBoxOperator jcfind = new JComboBoxOperator(FindQuestion, findWhere);
+          jcfind.selectItem(3);
+     }
+
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind5.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind5.java
@@ -1,0 +1,127 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigSearchFind;
+
+/**
+ * This test case verifies that an exactly string in the interview could be displayed when Consider case checkbox is check on.
+ */
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+import jthtest.ConfigTools;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JCheckBoxOperator;
+import org.netbeans.jemmy.operators.JComboBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JRadioButtonOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.Dumper;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.Config_Load.Config_Load;
+import jthtest.Tools.WDLoadingResult;
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.menu.Menu;
+
+public class ConfigSearchFind5 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigSearchFind.ConfigSearchFind5");
+     }
+
+     @Test
+     public void testConfig_Load1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Load existing configuration file
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+          Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+          // Edit Configuration
+          JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+          jmbo.pushMenuNoBlock("Configure", "/");
+          Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+          JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+
+          JDialogOperator config = findConfigEditor(mainFrame);
+          pushNextConfigEditor(config);
+
+          clickOnFind(configEditorDialog, "Java");
+
+          ComponentChooser qu1 = new NameComponentChooser("qu.title");
+          JTextFieldOperator testConfig1 = new JTextFieldOperator(configEditorDialog, qu1);
+          Thread.sleep(2000);
+          Assert.assertTrue("The interview should display the question that has Java and not java string in it.",
+                    testConfig1.getText().equals("Java Virtual Machine"));
+
+     }
+
+     // Click on Search-->Find
+     public void clickOnFind(JDialogOperator configEditorDialog, String textToSearch) throws InterruptedException {
+          JMenuBarOperator jmbo1 = new JMenuBarOperator(configEditorDialog);
+          jmbo1.pushMenu("Search", "/");
+          jmbo1.pushMenu("Search/Find...", "/");
+          JDialogOperator FindQuestion = new JDialogOperator("Find Question");
+          Thread.sleep(1000);
+          JTextFieldOperator javastring = new JTextFieldOperator(FindQuestion);
+          javastring.enterText(textToSearch);
+
+          ComponentChooser findCase = new NameComponentChooser("find.case");
+          JCheckBoxOperator considerCase = new JCheckBoxOperator(FindQuestion, findCase);
+          Thread.sleep(2000);
+          considerCase.doClick();
+
+          JButtonOperator findButton = new JButtonOperator(FindQuestion, "Find");
+          findButton.doClick();
+     }
+
+}


### PR DESCRIPTION
Adding below automated legacy JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux, Windows, Mac OS(JDK 1.8)) and working fine.

1. ConfigSearchFind1.java
2. ConfigSearchFind2.java
3. ConfigSearchFind3.java
4. ConfigSearchFind4.java
5. ConfigSearchFind5.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904018](https://bugs.openjdk.org/browse/CODETOOLS-7904018): Feature Tests - Adding JavaTest GUI newly automated test scripts. (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jtharness.git pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/97.diff">https://git.openjdk.org/jtharness/pull/97.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/97#issuecomment-2897738502)
</details>
