### PR TITLE
7904044: Feature Tests - Adding JavaTest GUI newly automated test scripts.

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ConfigQuestionLog/ConfigQuestionLog1.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigQuestionLog/ConfigQuestionLog1.java
@@ -1,0 +1,85 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigQuestionLog;
+
+import java.awt.Component;
+
+/**
+ * This test case verifies that a string in the interview could be displayed when search option is "In titles".
+ */
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+
+import jthtest.ConfigTools;
+
+public class ConfigQuestionLog1 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigQuestionLog1");
+     }
+
+     @Test
+     public void ConfigQuestionLog1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          /**
+           * Verify that Show Question Log under the View->Configuration menu will display
+           * the current configuration for a test run.
+           */
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Open the "File" menu
+          new JMenuOperator(mainFrame, "View").pushMenu("View|Configuration|Show Question Log...", "|");
+          new JDialogOperator(mainFrame, "Configuration Question Log");
+
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigQuestionLog/ConfigQuestionLog2.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigQuestionLog/ConfigQuestionLog2.java
@@ -1,0 +1,115 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigQuestionLog;
+
+import java.awt.Component;
+import java.io.File;
+
+/**
+ * This test case verifies that a string in the interview could be displayed when search option is "In titles".
+ */
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JTextField;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.ComponentOperator;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JComponentOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JLabelOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JTextComponentOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator.JTextFieldFinder;
+import org.netbeans.jemmy.util.Dumper;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.ConfigTools;
+import jthtest.Tools;
+
+public class ConfigQuestionLog2 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigQuestionLog2");
+     }
+
+     @Test
+     public void ConfigQuestionLog1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          /**
+           * Verify that the content of question log will be saved in a specified
+           * directory.
+           */
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Open the "Show Question Log..." menu
+          new JMenuOperator(mainFrame, "View").pushMenu("View|Configuration|Show Question Log...", "|");
+          JDialogOperator cql = new JDialogOperator(mainFrame, "Configuration Question Log");
+
+          // Save the "Save Configuration Question Log"
+          new JMenuOperator(cql, "File").pushMenuNoBlock("File|Save As", "|");
+          JDialogOperator scql = new JDialogOperator("Save Configuration Question Log");
+          Dumper.dumpAll("temp.txt");
+
+          // enter the file name
+          JTextFieldOperator scqltxt = new JTextFieldOperator(scql);
+          scqltxt.setText("currconfig");
+
+          // save the file
+          JButtonOperator scqljb = new JButtonOperator(scql, "Save");
+          scqljb.push();
+
+          // Assert the validation
+          File temp = new File("//" + Tools.DEFAULT_PATH + "currconfig.html");
+          Assert.assertTrue("Verify that the current configuration should be saved in html file.", temp.exists());
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind6.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigSearchFind/ConfigSearchFind6.java
@@ -1,0 +1,117 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigSearchFind;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.DialogOperator;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JCheckBoxOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.ConfigTools;
+import jthtest.Config_Edit.Config_Edit;
+
+public class ConfigSearchFind6 extends ConfigTools {
+
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigSearchFind.ConfigSearchFind6");
+     }
+
+     @Test
+     public void ConfigSearchFind6() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
+
+          /**
+           * This test case verifies that a string as whole word in the interview could be
+           * displayed when Whole words checkbox is check on.
+           */
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Load existing configuration file
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+          Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+          // Bring up Edit Configuration editor by doing Ctrl-E
+          mainFrame.pushKey(java.awt.event.KeyEvent.VK_E, java.awt.event.InputEvent.CTRL_MASK);
+
+          // Get the Edit Configuration dialog
+          JDialogOperator editConfigDialog = new JDialogOperator(mainFrame);
+
+          // Bring up Find from Search menu
+          JMenuBarOperator jmbo1 = new JMenuBarOperator(editConfigDialog);
+          jmbo1.pushMenu("Search", "/");
+          jmbo1.pushMenu("Search/Find...", "/");
+
+          // Get the Find dialog
+          DialogOperator findDialog = new DialogOperator("Find Question");
+
+          // Enter "elco" in the edit line
+          JTextFieldOperator textFieldOperator = new JTextFieldOperator(findDialog);
+          textFieldOperator.clearText();
+          textFieldOperator.enterText("elco");
+
+          // Check Whole words checkbox on
+          JCheckBoxOperator wholeWordsCheckBox = new JCheckBoxOperator(findDialog, "Whole words");
+          wholeWordsCheckBox.doClick();
+
+          // Click on Find
+          JButtonOperator findButton = new JButtonOperator(findDialog, "Find");
+          findButton.push();
+
+          // Verify that only questions with whole word "elco" will be found
+          // Assuming the results are displayed in a JList
+          JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+          ComponentChooser qu = new NameComponentChooser("qu.title");
+          JTextFieldOperator testConfig1 = new JTextFieldOperator(configEditorDialog, qu);
+
+          Assert.assertFalse("Only the questions with whole word elcom will be found and not Welcome",
+                    testConfig1.getText().contains("welcome"));
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigViewEdit/ConfigViewEdit1.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigViewEdit/ConfigViewEdit1.java
@@ -1,0 +1,109 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigViewEdit;
+
+import java.awt.Component;
+
+/**
+ * This test case verifies that a string in the interview could be displayed when search option is "In titles".
+ */
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JMenuBarOperator;
+import org.netbeans.jemmy.operators.JMenuOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.util.Dumper;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import jthtest.ConfigTools;
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.menu.Menu;
+
+public class ConfigViewEdit1 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigQuestionLog1");
+     }
+
+     @Test
+     public void ConfigViewEdit1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          /**
+           * This test case verifies that Question Mode radio is always selected.
+           */
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Load existing configuration file
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+          Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+          // Edit existing Configuration
+          JMenuBarOperator jmbo = new JMenuBarOperator(mainFrame);
+          jmbo.pushMenuNoBlock("Configure", "/");
+          Menu.getConfigure_EditConfigurationMenu(mainFrame).pushNoBlock();
+          JDialogOperator configEditorDialog = new JDialogOperator(getExecResource("ce.name"));
+
+          // Bring up Edit Configuration editor by doing Ctrl-E
+          mainFrame.pushKey(java.awt.event.KeyEvent.VK_E, java.awt.event.InputEvent.CTRL_MASK);
+
+          JMenuOperator jm = new JMenuOperator(mainFrame, "View");
+          jm.pushMenu("View", "|");
+
+          ComponentChooser ce = new NameComponentChooser("ce.view");
+          JMenuOperator QuestonMode = new JMenuOperator(configEditorDialog, ce);
+
+          Assert.assertTrue("The Question Mode radio should be selected by default", QuestonMode.isEnabled());
+
+     }
+}


### PR DESCRIPTION
Adding below automated newly JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux,Mac OS(JDK 1.8) and Windows ) and working fine.

1. ConfigSearchFind6.java
2. ConfigQuestionLog1.java
3. ConfigQuestionLog2.java
4. ConfigViewEdit1.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904044](https://bugs.openjdk.org/browse/CODETOOLS-7904044): Feature Tests - Adding JavaTest GUI newly automated test scripts. (**Sub-task** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jtharness.git pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/98.diff">https://git.openjdk.org/jtharness/pull/98.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/98#issuecomment-2994365371)
</details>
