### PR TITLE
7904111: Feature Tests - Adding JavaTest GUI newly automated test scripts.

### DIFF
--- a/gui-tests/src/gui/src/jthtest/ConfigEnvBrowser/ConfigEnvBrowser1.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigEnvBrowser/ConfigEnvBrowser1.java
@@ -1,0 +1,95 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigEnvBrowser;
+
+import jthtest.ConfigTools;
+import jthtest.Config_Edit.Config_Edit;
+import jthtest.menu.Menu;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.ComponentChooser;
+import org.netbeans.jemmy.operators.*;
+import org.netbeans.jemmy.util.NameComponentChooser;
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+
+public class ConfigEnvBrowser1 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigEnvBrowser1");
+     }
+
+    /**
+     * This test case verifies that Show Test Environment browser will display the current configuration if config file is open.
+     */
+
+     @Test
+     public void ConfigEnvBrowser1() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          /**
+           * This test case verifies that Question Mode radio is always selected.
+           */
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+          // Load existing configuration file
+          openConfigFile(openLoadConfigDialogByMenu(mainFrame), CONFIG_NAME);
+          Config_Edit.waitForConfigurationLoading(mainFrame, CONFIG_NAME);
+
+         JMenuBarOperator menuBar = new JMenuBarOperator(mainFrame);
+         menuBar.pushMenuNoBlock("View|Configuration|Show Test Environment");
+
+         // Verify dialog is displayed and configuration values are present
+         JDialogOperator envDialog = new JDialogOperator("Test Environment: democonfig"); // dialog title as seen
+         // Check that at least one row exists in the environment table
+         JTableOperator table = new JTableOperator(envDialog);
+         int rowCount = table.getRowCount();
+         Thread.sleep(3000);
+
+         Assert.assertTrue("Test Failed: The Test Environment dialog should be displayed with all the values in the configuration.", rowCount > 0);
+
+         // Close the dialog
+         new JButtonOperator(envDialog, "Close").push();
+
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigEnvBrowser/ConfigEnvBrowser2.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigEnvBrowser/ConfigEnvBrowser2.java
@@ -1,0 +1,83 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigEnvBrowser;
+
+import jthtest.ConfigTools;
+import jthtest.Config_Edit.Config_Edit;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.*;
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+
+public class ConfigEnvBrowser2 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigEnvBrowser2");
+     }
+
+    /**
+     * This test case verifies that Show Test Environment browser will be empty if there is no configure file open.
+     */
+
+     @Test
+     public void ConfigEnvBrowser2() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+         JMenuBarOperator menuBar = new JMenuBarOperator(mainFrame);
+         menuBar.pushMenuNoBlock("View|Configuration|Show Test Environment");
+
+         // Verify dialog is displayed and configuration values are present
+         JDialogOperator envDialog = new JDialogOperator("Test Environment: unknown"); // dialog title as seen
+         // Check that at least one row exists in the environment table
+         JTableOperator table = new JTableOperator(envDialog);
+         int rowCount = table.getRowCount();
+         Thread.sleep(3000);
+
+         assert rowCount == 0 : "Test Failed: The Test Environment dialog should be displayed with no values.";
+
+         // Close the dialog
+         new JButtonOperator(envDialog, "Close").push();
+
+     }
+}

--- a/gui-tests/src/gui/src/jthtest/ConfigEnvBrowser/ConfigEnvBrowser3.java
+++ b/gui-tests/src/gui/src/jthtest/ConfigEnvBrowser/ConfigEnvBrowser3.java
@@ -1,0 +1,85 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jthtest.ConfigEnvBrowser;
+
+import jthtest.ConfigTools;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.netbeans.jemmy.operators.*;
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+
+public class ConfigEnvBrowser3 extends ConfigTools {
+     public static void main(String[] args) {
+          JUnitCore.main("jthtest.gui.ConfigEnvBrowser3");
+     }
+
+    /**
+     * This test case verifies that a single click on help Button in Test environment Dialog shall bring up the online help TestEnvironment Dialog Box page.
+     */
+
+     @Test
+     public void ConfigEnvBrowser3() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException,
+               InterruptedException, FileNotFoundException {
+
+          // Start Java Test application with -newDesktop
+          startJavatestNewDesktop();
+
+          // get the reference of mainframe
+          JFrameOperator mainFrame = findMainFrame();
+
+          // Close Quick Start Dialog window
+          closeQS(mainFrame);
+
+          // Open default test suite
+          openTestSuite(mainFrame);
+
+          // Create work directory
+          createWorkDirInTemp(mainFrame);
+
+         JMenuBarOperator menuBar = new JMenuBarOperator(mainFrame);
+         menuBar.pushMenuNoBlock("View|Configuration|Show Test Environment");
+
+         // Verify dialog is displayed and configuration values are present
+         JDialogOperator envDialog = new JDialogOperator("Test Environment: unknown"); // dialog title as seen
+         // Check that at least one row exists in the environment table
+         JTableOperator table = new JTableOperator(envDialog);
+         int rowCount = table.getRowCount();
+         Thread.sleep(3000);
+
+         JButtonOperator helpButton = new JButtonOperator(envDialog, "Help");
+         helpButton.push();
+
+         // Check if the help file exists
+         String helpFilePath = System.getProperty("user.home") + "/.javatest/jthelp/com/sun/javatest/help/default/env/dialog.html";
+         java.io.File helpFile = new java.io.File(helpFilePath);
+         assert helpFile.exists() : "The correct JavaTest online help window does not exists at " + helpFilePath;
+
+     }
+}


### PR DESCRIPTION
Adding below automated newly JavaTest GUI feature Test Scripts to the Jemmy regression suite and tested locally on three platforms(Linux,Mac OS(JDK 1.8) and  Windows ) and working fine.

1. ConfigEnvBrowser1.java
2. ConfigEnvBrowser2.java
3. ConfigEnvBrowser3.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904111](https://bugs.openjdk.org/browse/CODETOOLS-7904111): Feature Tests - Adding JavaTest GUI newly automated test scripts. (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtharness.git pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/jtharness.git pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtharness/pull/99.diff">https://git.openjdk.org/jtharness/pull/99.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtharness/pull/99#issuecomment-3491276042)
</details>
